### PR TITLE
chore: remove release-as now that v0.1.0 is published

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Remove `release-as: 0.1.0` from release-please config
- Future versions will be auto-calculated from conventional commits