### PR TITLE
feat: add common/global PII detectors

### DIFF
--- a/adapter/detector/common/common_test.go
+++ b/adapter/detector/common/common_test.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*EmailDetector)(nil)
+	_ port.Detector = (*CreditCardDetector)(nil)
+	_ port.Detector = (*IPDetector)(nil)
+	_ port.Detector = (*URLDetector)(nil)
+	_ port.Detector = (*IBANDetector)(nil)
+	_ port.Detector = (*MACDetector)(nil)
+)
+
+func TestEmailDetector(t *testing.T) {
+	d := NewEmailDetector()
+
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"email john@example.com here", 1},
+		{"user.name+tag@domain.co.uk", 1},
+		{"a@b.cd and x@y.ef", 2},
+		{"no email here", 0},
+		{"@@invalid", 0},
+		{"test@", 0},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("Detect(%q) got %d matches, want %d", tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Email {
+				t.Errorf("expected Email type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestCreditCardDetector(t *testing.T) {
+	d := NewCreditCardDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"4111111111111111", 1, "Visa"},
+		{"4111 1111 1111 1111", 1, "Visa with spaces"},
+		{"4111-1111-1111-1111", 1, "Visa with dashes"},
+		{"5500000000000004", 1, "Mastercard"},
+		{"378282246310005", 1, "Amex"},
+		{"6011111111111117", 1, "Discover"},
+		{"1234567890123456", 0, "invalid Luhn"},
+		{"123", 0, "too short"},
+		{"no card here", 0, "no digits"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestLuhn(t *testing.T) {
+	if !luhn("4111111111111111") {
+		t.Error("Visa test number should pass Luhn")
+	}
+	if luhn("4111111111111112") {
+		t.Error("Invalid number should fail Luhn")
+	}
+	if luhn("") {
+		t.Error("Empty string should fail Luhn")
+	}
+}
+
+func TestIPDetector(t *testing.T) {
+	d := NewIPDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"IP is 192.168.1.1 here", 1, "simple IPv4"},
+		{"10.0.0.1 and 172.16.0.1", 2, "two IPv4"},
+		{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", 1, "full IPv6"},
+		{"::1", 1, "loopback IPv6"},
+		{"999.999.999.999", 0, "invalid octets"},
+		{"no ip here", 0, "no IP"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestURLDetector(t *testing.T) {
+	d := NewURLDetector()
+
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"visit https://example.com/path?q=1 now", 1},
+		{"http://localhost:8080", 1},
+		{"https://a.com and https://b.com", 2},
+		{"ftp://notmatched.com", 0},
+		{"no url here", 0},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("Detect(%q) got %d matches, want %d", tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestIBANDetector(t *testing.T) {
+	d := NewIBANDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"IBAN: NL91ABNA0417164300", 1, "valid NL IBAN"},
+		{"DE89370400440532013000", 1, "valid DE IBAN"},
+		{"GB29NWBK60161331926819", 1, "valid GB IBAN"},
+		{"NL00ABNA0000000000", 0, "invalid checksum"},
+		{"no iban here", 0, "no IBAN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestMACDetector(t *testing.T) {
+	d := NewMACDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"MAC: 00:1A:2B:3C:4D:5E", 1, "colon-separated"},
+		{"00-1A-2B-3C-4D-5E", 1, "hyphen-separated"},
+		{"001A.2B3C.4D5E", 1, "dot-separated"},
+		{"not a mac address", 0, "no MAC"},
+		{"00:1A:2B", 0, "too short"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}

--- a/adapter/detector/common/creditcard.go
+++ b/adapter/detector/common/creditcard.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 13-19 digit sequences optionally separated by spaces or hyphens.
+var creditCardRe = regexp.MustCompile(`\b(?:\d[ \-]*?){13,19}\b`)
+
+// CreditCardDetector detects credit card numbers using pattern matching and Luhn validation.
+type CreditCardDetector struct{}
+
+func NewCreditCardDetector() *CreditCardDetector { return &CreditCardDetector{} }
+
+func (d *CreditCardDetector) Name() string              { return "common/creditcard" }
+func (d *CreditCardDetector) Locales() []string         { return nil }
+func (d *CreditCardDetector) PIITypes() []model.PIIType { return []model.PIIType{model.CreditCard} }
+
+func (d *CreditCardDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	locs := creditCardRe.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range locs {
+		raw := text[loc[0]:loc[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) < 13 || len(digits) > 19 {
+			continue
+		}
+		if !luhn(digits) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.CreditCard,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.95,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// luhn validates a number string using the Luhn algorithm.
+func luhn(digits string) bool {
+	if len(digits) == 0 {
+		return false
+	}
+	sum := 0
+	alt := false
+	for i := len(digits) - 1; i >= 0; i-- {
+		n := int(digits[i] - '0')
+		if alt {
+			n *= 2
+			if n > 9 {
+				n -= 9
+			}
+		}
+		sum += n
+		alt = !alt
+	}
+	return sum%10 == 0
+}

--- a/adapter/detector/common/email.go
+++ b/adapter/detector/common/email.go
@@ -1,0 +1,24 @@
+// Package common provides PII detectors for locale-independent patterns.
+package common
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+var emailRe = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+
+// EmailDetector detects email addresses.
+type EmailDetector struct{}
+
+func NewEmailDetector() *EmailDetector { return &EmailDetector{} }
+
+func (d *EmailDetector) Name() string              { return "common/email" }
+func (d *EmailDetector) Locales() []string         { return nil }
+func (d *EmailDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Email} }
+
+func (d *EmailDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(emailRe, text, model.Email, 0.95, d.Name()), nil
+}

--- a/adapter/detector/common/helpers.go
+++ b/adapter/detector/common/helpers.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/common/iban.go
+++ b/adapter/detector/common/iban.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"context"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// IBAN: 2 letter country code + 2 check digits + up to 30 alphanumeric chars.
+var ibanRe = regexp.MustCompile(`\b[A-Z]{2}\d{2}[A-Z0-9]{4,30}\b`)
+
+// IBANDetector detects International Bank Account Numbers with mod-97 validation.
+type IBANDetector struct{}
+
+func NewIBANDetector() *IBANDetector { return &IBANDetector{} }
+
+func (d *IBANDetector) Name() string              { return "common/iban" }
+func (d *IBANDetector) Locales() []string         { return nil }
+func (d *IBANDetector) PIITypes() []model.PIIType { return []model.PIIType{model.IBAN} }
+
+func (d *IBANDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	locs := ibanRe.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range locs {
+		val := text[loc[0]:loc[1]]
+		if !validateIBANChecksum(val) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.IBAN,
+			Value:      val,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.95,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// validateIBANChecksum performs the ISO 13616 mod-97 check.
+func validateIBANChecksum(iban string) bool {
+	iban = strings.ToUpper(strings.ReplaceAll(iban, " ", ""))
+	if len(iban) < 5 {
+		return false
+	}
+
+	// Move the first 4 characters to the end.
+	rearranged := iban[4:] + iban[:4]
+
+	// Convert letters to numbers (A=10, B=11, ..., Z=35).
+	var numeric strings.Builder
+	for _, r := range rearranged {
+		if r >= 'A' && r <= 'Z' {
+			numeric.WriteString(strconv.Itoa(int(r - 'A' + 10)))
+		} else {
+			numeric.WriteRune(r)
+		}
+	}
+
+	n := new(big.Int)
+	n.SetString(numeric.String(), 10)
+	mod := new(big.Int)
+	mod.Mod(n, big.NewInt(97))
+
+	return mod.Int64() == 1
+}

--- a/adapter/detector/common/ip.go
+++ b/adapter/detector/common/ip.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+var (
+	ipv4Re = regexp.MustCompile(`\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b`)
+	ipv6Re = regexp.MustCompile(`(?i)(?:\b(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}\b|(?:\b[0-9a-f]{1,4}:){1,7}:|(?:\b[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}\b|::(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4}\b|::)`)
+)
+
+// IPDetector detects IPv4 and IPv6 addresses.
+type IPDetector struct{}
+
+func NewIPDetector() *IPDetector { return &IPDetector{} }
+
+func (d *IPDetector) Name() string              { return "common/ip" }
+func (d *IPDetector) Locales() []string         { return nil }
+func (d *IPDetector) PIITypes() []model.PIIType { return []model.PIIType{model.IPAddress} }
+
+func (d *IPDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	var matches []model.Match
+
+	// IPv4
+	for _, loc := range ipv4Re.FindAllStringIndex(text, -1) {
+		val := text[loc[0]:loc[1]]
+		if isValidIPv4(val) {
+			matches = append(matches, model.Match{
+				Type:       model.IPAddress,
+				Value:      val,
+				Start:      loc[0],
+				End:        loc[1],
+				Confidence: 0.9,
+				Detector:   d.Name(),
+			})
+		}
+	}
+
+	// IPv6
+	matches = append(matches, findAll(ipv6Re, text, model.IPAddress, 0.9, d.Name())...)
+
+	return matches, nil
+}
+
+func isValidIPv4(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return false
+		}
+	}
+	return true
+}

--- a/adapter/detector/common/mac.go
+++ b/adapter/detector/common/mac.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches colon-separated, hyphen-separated, and dot-separated MAC formats.
+var macRe = regexp.MustCompile(`(?i)\b(?:[0-9a-f]{2}[:\-]){5}[0-9a-f]{2}\b|(?i)\b(?:[0-9a-f]{4}\.){2}[0-9a-f]{4}\b`)
+
+// MACDetector detects MAC addresses.
+type MACDetector struct{}
+
+func NewMACDetector() *MACDetector { return &MACDetector{} }
+
+func (d *MACDetector) Name() string              { return "common/mac" }
+func (d *MACDetector) Locales() []string         { return nil }
+func (d *MACDetector) PIITypes() []model.PIIType { return []model.PIIType{model.MACAddress} }
+
+func (d *MACDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(macRe, text, model.MACAddress, 0.9, d.Name()), nil
+}

--- a/adapter/detector/common/url.go
+++ b/adapter/detector/common/url.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+var urlRe = regexp.MustCompile(`https?://[^\s<>"{}|\\^\x60\[\]]+`)
+
+// URLDetector detects URLs with http/https schemes.
+type URLDetector struct{}
+
+func NewURLDetector() *URLDetector { return &URLDetector{} }
+
+func (d *URLDetector) Name() string              { return "common/url" }
+func (d *URLDetector) Locales() []string         { return nil }
+func (d *URLDetector) PIITypes() []model.PIIType { return []model.PIIType{model.URL} }
+
+func (d *URLDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(urlRe, text, model.URL, 0.9, d.Name()), nil
+}


### PR DESCRIPTION
## Summary
- Email detector (RFC 5322 pattern)
- Credit Card detector (regex + Luhn algorithm validation)
- IP detector (IPv4 octet validation + IPv6 compressed notation)
- URL detector (http/https schemes)
- IBAN detector (ISO 13616 format + mod-97 checksum)
- MAC Address detector (colon, hyphen, dot-separated formats)

All implement `port.Detector`. Helper utility `findAll` for regex-based detectors.

Closes #7

## Test plan
- [x] Unit tests with positive and negative cases for each detector
- [x] Luhn validation tested independently
- [x] IBAN mod-97 checksum with real NL/DE/GB IBANs
- [x] `go test -race ./...` passes
- [ ] CI checks pass