### PR TITLE
feat: add US PII detectors

### DIFF
--- a/adapter/detector/us/ein.go
+++ b/adapter/detector/us/ein.go
@@ -1,0 +1,24 @@
+package us
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// EIN format: XX-XXXXXXX. Valid prefixes per IRS campus assignment.
+var einRe = regexp.MustCompile(`\b(?:0[1-6]|1[0-6]|2[0-7]|3[0-9]|4[0-8]|5[0-9]|6[0-8]|7[1-7]|8[0-5]|9[0-5|8])-\d{7}\b`)
+
+// EINDetector detects US Employer Identification Numbers.
+type EINDetector struct{}
+
+func NewEINDetector() *EINDetector { return &EINDetector{} }
+
+func (d *EINDetector) Name() string              { return "us/ein" }
+func (d *EINDetector) Locales() []string         { return []string{locale} }
+func (d *EINDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *EINDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(einRe, text, model.TaxID, 0.85, d.Name()), nil
+}

--- a/adapter/detector/us/helpers.go
+++ b/adapter/detector/us/helpers.go
@@ -1,0 +1,31 @@
+// Package us provides PII detectors for United States-specific patterns.
+package us
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "us"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/us/itin.go
+++ b/adapter/detector/us/itin.go
@@ -1,0 +1,59 @@
+package us
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// ITIN: starts with 9, then 2 digits, then group, then 4 digits.
+var itinRe = regexp.MustCompile(`\b(9\d{2})-?(\d{2})-?(\d{4})\b`)
+
+// ITINDetector detects US Individual Taxpayer Identification Numbers.
+type ITINDetector struct{}
+
+func NewITINDetector() *ITINDetector { return &ITINDetector{} }
+
+func (d *ITINDetector) Name() string              { return "us/itin" }
+func (d *ITINDetector) Locales() []string         { return []string{locale} }
+func (d *ITINDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *ITINDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := itinRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		full := text[loc[0]:loc[1]]
+		group := text[loc[4]:loc[5]]
+
+		if !isValidITINGroup(group) {
+			continue
+		}
+
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      full,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.8,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidITINGroup checks that the group number is in valid ITIN ranges:
+// 50-65, 70-88, 90-92, 94-99.
+func isValidITINGroup(group string) bool {
+	g, err := strconv.Atoi(group)
+	if err != nil {
+		return false
+	}
+	return (g >= 50 && g <= 65) || (g >= 70 && g <= 88) || (g >= 90 && g <= 92) || (g >= 94 && g <= 99)
+}

--- a/adapter/detector/us/medicare.go
+++ b/adapter/detector/us/medicare.go
@@ -1,0 +1,25 @@
+package us
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Medicare Beneficiary Identifier (MBI): 11 chars, pattern C A AN N AA N AN AN.
+// C=1-9, A=A-Z(excl S,L,O,I,B,Z), N=0-9, AN=alphanumeric(excl S,L,O,I,B,Z).
+var medicareRe = regexp.MustCompile(`\b[1-9][A-HJKM-NP-RT-Y][A-HJKM-NP-RT-Y0-9]\d[A-HJKM-NP-RT-Y][A-HJKM-NP-RT-Y]\d[A-HJKM-NP-RT-Y][A-HJKM-NP-RT-Y0-9][A-HJKM-NP-RT-Y0-9]\d\b`)
+
+// MedicareDetector detects US Medicare Beneficiary Identifiers.
+type MedicareDetector struct{}
+
+func NewMedicareDetector() *MedicareDetector { return &MedicareDetector{} }
+
+func (d *MedicareDetector) Name() string              { return "us/medicare" }
+func (d *MedicareDetector) Locales() []string         { return []string{locale} }
+func (d *MedicareDetector) PIITypes() []model.PIIType { return []model.PIIType{model.HealthID} }
+
+func (d *MedicareDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(medicareRe, text, model.HealthID, 0.8, d.Name()), nil
+}

--- a/adapter/detector/us/passport.go
+++ b/adapter/detector/us/passport.go
@@ -1,0 +1,24 @@
+package us
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// US passport: 9 digits (may also have letter prefix in newer format).
+var passportRe = regexp.MustCompile(`\b[A-Z]?\d{8,9}\b`)
+
+// PassportDetector detects US passport numbers.
+type PassportDetector struct{}
+
+func NewPassportDetector() *PassportDetector { return &PassportDetector{} }
+
+func (d *PassportDetector) Name() string              { return "us/passport" }
+func (d *PassportDetector) Locales() []string         { return []string{locale} }
+func (d *PassportDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Passport} }
+
+func (d *PassportDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(passportRe, text, model.Passport, 0.6, d.Name()), nil
+}

--- a/adapter/detector/us/phone.go
+++ b/adapter/detector/us/phone.go
@@ -1,0 +1,25 @@
+package us
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// NANP phone: optional +1/1 prefix, area code (2-9XX), 7-digit subscriber number.
+// Supports parens, spaces, dots, and dashes as separators.
+var phoneRe = regexp.MustCompile(`(?:\+?1[\s.\-]?)?\(?[2-9]\d{2}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}`)
+
+// PhoneDetector detects US phone numbers in NANP format.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "us/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(phoneRe, text, model.Phone, 0.8, d.Name()), nil
+}

--- a/adapter/detector/us/ssn.go
+++ b/adapter/detector/us/ssn.go
@@ -1,0 +1,67 @@
+package us
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 3-2-4 digit patterns with optional dashes.
+var ssnRe = regexp.MustCompile(`\b(\d{3})-?(\d{2})-?(\d{4})\b`)
+
+// SSNDetector detects US Social Security Numbers.
+type SSNDetector struct{}
+
+func NewSSNDetector() *SSNDetector { return &SSNDetector{} }
+
+func (d *SSNDetector) Name() string              { return "us/ssn" }
+func (d *SSNDetector) Locales() []string         { return []string{locale} }
+func (d *SSNDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *SSNDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := ssnRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		full := text[loc[0]:loc[1]]
+		area := text[loc[2]:loc[3]]
+		group := text[loc[4]:loc[5]]
+		serial := text[loc[6]:loc[7]]
+
+		if !isValidSSN(area, group, serial) {
+			continue
+		}
+
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      full,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+func isValidSSN(area, group, serial string) bool {
+	// Area cannot be 000, 666, or 900-999.
+	if area == "000" || area == "666" || strings.HasPrefix(area, "9") {
+		return false
+	}
+	// Group cannot be 00.
+	if group == "00" {
+		return false
+	}
+	// Serial cannot be 0000.
+	if serial == "0000" {
+		return false
+	}
+	return true
+}

--- a/adapter/detector/us/us_test.go
+++ b/adapter/detector/us/us_test.go
@@ -1,0 +1,213 @@
+package us
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*SSNDetector)(nil)
+	_ port.Detector = (*EINDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*ZIPDetector)(nil)
+	_ port.Detector = (*PassportDetector)(nil)
+	_ port.Detector = (*ITINDetector)(nil)
+	_ port.Detector = (*MedicareDetector)(nil)
+)
+
+func TestSSNDetector(t *testing.T) {
+	d := NewSSNDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"SSN: 123-45-6789", 1, "standard format"},
+		{"123456789", 1, "no dashes"},
+		{"000-12-3456", 0, "area 000 invalid"},
+		{"666-12-3456", 0, "area 666 invalid"},
+		{"900-12-3456", 0, "area 900+ invalid"},
+		{"123-00-6789", 0, "group 00 invalid"},
+		{"123-45-0000", 0, "serial 0000 invalid"},
+		{"no ssn here", 0, "no SSN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "us" {
+				t.Errorf("expected locale 'us', got %q", m.Locale)
+			}
+		}
+	}
+}
+
+func TestEINDetector(t *testing.T) {
+	d := NewEINDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"EIN: 12-3456789", 1, "valid EIN"},
+		{"01-1234567", 1, "valid prefix 01"},
+		{"00-1234567", 0, "invalid prefix 00"},
+		{"99-1234567", 0, "invalid prefix 99"},
+		{"no ein here", 0, "no EIN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Call (555) 123-4567", 1, "parenthesized area code"},
+		{"+1-555-123-4567", 1, "international format"},
+		{"555.123.4567", 1, "dot-separated"},
+		{"5551234567", 1, "no separators"},
+		{"1-800-555-1234", 1, "toll-free"},
+		{"123-456", 0, "too short"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestZIPDetector(t *testing.T) {
+	d := NewZIPDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"ZIP: 90210", 1, "5-digit ZIP"},
+		{"90210-1234", 1, "ZIP+4"},
+		{"1234", 0, "too short"},
+		{"no zip here", 0, "no ZIP"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestPassportDetector(t *testing.T) {
+	d := NewPassportDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Passport: 123456789", 1, "9-digit"},
+		{"C12345678", 1, "letter prefix"},
+		{"1234567", 0, "too short"},
+		{"no passport", 0, "no passport"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestITINDetector(t *testing.T) {
+	d := NewITINDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"ITIN: 912-50-1234", 1, "valid ITIN with group 50"},
+		{"970-70-1234", 1, "valid ITIN with group 70"},
+		{"912501234", 1, "no dashes"},
+		{"no itin here", 0, "no ITIN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+	}
+}
+
+func TestMedicareDetector(t *testing.T) {
+	d := NewMedicareDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"MBI: 1EG4TE5MK72", 1, "valid MBI"},
+		{"no medicare", 0, "no MBI"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.HealthID {
+				t.Errorf("expected HealthID type, got %v", m.Type)
+			}
+		}
+	}
+}

--- a/adapter/detector/us/zip.go
+++ b/adapter/detector/us/zip.go
@@ -1,0 +1,24 @@
+package us
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// ZIP code: 5 digits, optionally followed by -XXXX (ZIP+4).
+var zipRe = regexp.MustCompile(`\b\d{5}(?:-\d{4})?\b`)
+
+// ZIPDetector detects US ZIP codes.
+type ZIPDetector struct{}
+
+func NewZIPDetector() *ZIPDetector { return &ZIPDetector{} }
+
+func (d *ZIPDetector) Name() string              { return "us/zip" }
+func (d *ZIPDetector) Locales() []string         { return []string{locale} }
+func (d *ZIPDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *ZIPDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(zipRe, text, model.PostalCode, 0.6, d.Name()), nil
+}


### PR DESCRIPTION
## Summary
- SSN detector (area/group/serial validation, excludes invalid ranges)
- EIN detector (IRS campus prefix validation)
- Phone detector (NANP format — parens, dots, dashes, spaces)
- ZIP detector (5-digit and ZIP+4)
- Passport detector (9-digit with optional letter prefix)
- ITIN detector (9XX with valid group range 50-65, 70-88, 90-92, 94-99)
- Medicare detector (MBI 11-character format)

All implement `port.Detector` with locale `"us"`.

Closes #8

## Test plan
- [x] Unit tests with valid/invalid cases for each detector
- [x] SSN excludes 000, 666, 900+ areas; 00 groups; 0000 serials
- [x] `go test -race ./...` passes
- [ ] CI checks pass