### PR TITLE
fix: allow feat: to bump minor version pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Remove `bump-patch-for-minor-pre-major` which was demoting `feat:` to patch bumps pre-1.0
- Now `feat:` correctly bumps minor (0.1.0 → 0.2.0) and `fix:` bumps patch (0.1.0 → 0.1.1)