### PR TITLE
feat: add EU-wide PII detectors — VAT ID, passport MRZ

### DIFF
--- a/adapter/detector/eu/eu_test.go
+++ b/adapter/detector/eu/eu_test.go
@@ -1,0 +1,115 @@
+package eu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*VATDetector)(nil)
+	_ port.Detector = (*PassportMRZDetector)(nil)
+)
+
+func TestVATDetector(t *testing.T) {
+	d := NewVATDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"VAT: ATU12345678", 1, "Austria"},
+		{"VAT: BE0123456789", 1, "Belgium"},
+		{"VAT: DE123456789", 1, "Germany"},
+		{"VAT: FR1A123456789", 1, "France alphanumeric"},
+		{"VAT: NL123456789B01", 1, "Netherlands"},
+		{"VAT: PL1234567890", 1, "Poland"},
+		{"VAT: EL123456789", 1, "Greece"},
+		{"VAT: SE123456789012", 1, "Sweden"},
+		{"VAT: IE1A12345AB", 1, "Ireland two-letter suffix"},
+		{"VAT: CY12345678A", 1, "Cyprus"},
+		{"VAT: ESA1234567B", 1, "Spain"},
+		{"VAT: XX123456789", 0, "unknown country prefix"},
+		{"no vat here", 0, "no VAT"},
+		{"DE12345", 0, "too short for German VAT"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "eu" {
+				t.Errorf("expected locale 'eu', got %q", m.Locale)
+			}
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.90 {
+				t.Errorf("expected confidence 0.90, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPassportMRZDetector(t *testing.T) {
+	d := NewPassportMRZDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{
+			input: "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C36UTO7408122F1204159ZE184226B<<<<<10",
+			want:  1,
+			desc:  "valid TD3 MRZ",
+		},
+		{
+			input: "P<GBRSMITH<<JOHN<<<<<<<<<<<<<<<<<<<<<<<<<<<<\nAB12345670GBR8501011M2501015<<<<<<<<<<<<<<00",
+			want:  1,
+			desc:  "UK passport MRZ",
+		},
+		{
+			input: "P<DEUMULLER<<HANS<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\nC01X00T478DEU6408125F2010315D<<<<<<<<<<<<<<04",
+			want:  0,
+			desc:  "line 1 too long (>44 chars) — invalid",
+		},
+		{
+			input: "not a passport",
+			want:  0,
+			desc:  "no MRZ",
+		},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "eu" {
+				t.Errorf("expected locale 'eu', got %q", m.Locale)
+			}
+			if m.Type != model.Passport {
+				t.Errorf("expected Passport type, got %v", m.Type)
+			}
+			if m.Confidence != 0.95 {
+				t.Errorf("expected confidence 0.95, got %f", m.Confidence)
+			}
+		}
+	}
+}

--- a/adapter/detector/eu/helpers.go
+++ b/adapter/detector/eu/helpers.go
@@ -1,0 +1,31 @@
+// Package eu provides PII detectors for European Union-specific patterns.
+package eu
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "eu"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/eu/passport_mrz.go
+++ b/adapter/detector/eu/passport_mrz.go
@@ -1,0 +1,29 @@
+package eu
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// mrzRe matches ICAO 9303 TD3 (passport) Machine Readable Zone.
+// TD3 format consists of two lines of 44 characters each.
+// Line 1: document type, issuing state, name.
+// Line 2: passport number, check digit, nationality, DOB, sex, expiry, optional data.
+var mrzRe = regexp.MustCompile(
+	`(?m)P[<A-Z][A-Z]{3}[A-Z<]{39}\n[A-Z0-9<]{9}[0-9][A-Z]{3}[0-9]{6}[0-9][MF<][0-9]{6}[0-9][A-Z0-9<]{14}[0-9][0-9]`,
+)
+
+// PassportMRZDetector detects ICAO 9303 passport Machine Readable Zones.
+type PassportMRZDetector struct{}
+
+func NewPassportMRZDetector() *PassportMRZDetector { return &PassportMRZDetector{} }
+
+func (d *PassportMRZDetector) Name() string              { return "eu/passport_mrz" }
+func (d *PassportMRZDetector) Locales() []string         { return []string{locale} }
+func (d *PassportMRZDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Passport} }
+
+func (d *PassportMRZDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(mrzRe, text, model.Passport, 0.95, d.Name()), nil
+}

--- a/adapter/detector/eu/vat.go
+++ b/adapter/detector/eu/vat.go
@@ -1,0 +1,55 @@
+package eu
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// vatRe matches EU VAT identification numbers for all 27 member states.
+// Each country has a two-letter prefix followed by a country-specific format.
+var vatRe = regexp.MustCompile(
+	`\b(?:` +
+		`ATU\d{8}` +
+		`|BE[01]\d{9}` +
+		`|BG\d{9,10}` +
+		`|CY\d{8}[A-Z]` +
+		`|CZ\d{8,10}` +
+		`|DE\d{9}` +
+		`|DK\d{8}` +
+		`|EE\d{9}` +
+		`|EL\d{9}` +
+		`|ES[A-Z0-9]\d{7}[A-Z0-9]` +
+		`|FI\d{8}` +
+		`|FR[A-Z0-9]{2}\d{9}` +
+		`|HR\d{11}` +
+		`|HU\d{8}` +
+		`|IE\d[A-Z0-9]\d{5}[A-Z]{1,2}` +
+		`|IT\d{11}` +
+		`|LT\d{9,12}` +
+		`|LU\d{8}` +
+		`|LV\d{11}` +
+		`|MT\d{8}` +
+		`|NL\d{9}B\d{2}` +
+		`|PL\d{10}` +
+		`|PT\d{9}` +
+		`|RO\d{2,10}` +
+		`|SE\d{12}` +
+		`|SI\d{8}` +
+		`|SK\d{10}` +
+		`)` + `\b`,
+)
+
+// VATDetector detects EU VAT identification numbers.
+type VATDetector struct{}
+
+func NewVATDetector() *VATDetector { return &VATDetector{} }
+
+func (d *VATDetector) Name() string              { return "eu/vat" }
+func (d *VATDetector) Locales() []string         { return []string{locale} }
+func (d *VATDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *VATDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(vatRe, text, model.TaxID, 0.90, d.Name()), nil
+}


### PR DESCRIPTION
## Summary
- Implements issue #10: EU-wide PII detectors
- VAT ID detection covering all 27 EU member states
- Passport MRZ (Machine Readable Zone) detection per ICAO 9303

Closes #10

## Test plan
- [ ] `go test ./adapter/detector/eu/...` passes
- [ ] All detectors implement `port.Detector` interface
- [ ] VAT IDs validated for multiple country formats
- [ ] MRZ detection handles TD3 passport format