### PR TITLE
feat: add Netherlands PII detectors — BSN, phone, postal code, KvK, Dutch ID

### DIFF
--- a/adapter/detector/nl/bsn.go
+++ b/adapter/detector/nl/bsn.go
@@ -1,0 +1,77 @@
+package nl
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 9-digit sequences, optionally separated by dots or spaces (e.g. 123456789, 123.456.789, 123 456 789).
+var bsnRe = regexp.MustCompile(`\b\d{3}[.\s]?\d{3}[.\s]?\d{3}\b`)
+
+// BSNDetector detects Dutch Burgerservicenummer (citizen service numbers).
+type BSNDetector struct{}
+
+func NewBSNDetector() *BSNDetector { return &BSNDetector{} }
+
+func (d *BSNDetector) Name() string              { return "nl/bsn" }
+func (d *BSNDetector) Locales() []string         { return []string{locale} }
+func (d *BSNDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *BSNDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := bsnRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) != 9 {
+			continue
+		}
+		if !isValid11Proof(digits) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// stripNonDigits removes all non-digit characters from s.
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// isValid11Proof checks the BSN 11-proof checksum.
+// Formula: 9*d1 + 8*d2 + 7*d3 + 6*d4 + 5*d5 + 4*d6 + 3*d7 + 2*d8 - 1*d9
+// Result must be divisible by 11 and must not be 0.
+func isValid11Proof(digits string) bool {
+	if len(digits) != 9 {
+		return false
+	}
+	weights := []int{9, 8, 7, 6, 5, 4, 3, 2, -1}
+	sum := 0
+	for i, w := range weights {
+		d := int(digits[i] - '0')
+		sum += w * d
+	}
+	return sum != 0 && sum%11 == 0
+}

--- a/adapter/detector/nl/helpers.go
+++ b/adapter/detector/nl/helpers.go
@@ -1,0 +1,31 @@
+// Package nl provides PII detectors for Netherlands-specific patterns.
+package nl
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "nl"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/nl/id_document.go
+++ b/adapter/detector/nl/id_document.go
@@ -1,0 +1,105 @@
+package nl
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Dutch ID card: pattern like SPECI2014 — a mix of uppercase letters and digits, 9 characters.
+var dutchIDRe = regexp.MustCompile(`\b[A-Z]{2,5}[A-Z0-9]{4,7}\b`)
+
+// Dutch passport: 2 uppercase letters followed by 7 alphanumeric characters.
+var dutchPassportRe = regexp.MustCompile(`\b[A-Z]{2}[A-Z0-9]{7}\b`)
+
+// IDDocumentDetector detects Dutch ID card and passport numbers.
+type IDDocumentDetector struct{}
+
+func NewIDDocumentDetector() *IDDocumentDetector { return &IDDocumentDetector{} }
+
+func (d *IDDocumentDetector) Name() string      { return "nl/id_document" }
+func (d *IDDocumentDetector) Locales() []string { return []string{locale} }
+func (d *IDDocumentDetector) PIITypes() []model.PIIType {
+	return []model.PIIType{model.NationalID, model.Passport}
+}
+
+func (d *IDDocumentDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	var matches []model.Match
+
+	// Detect Dutch ID cards (9-character alphanumeric).
+	for _, loc := range dutchIDRe.FindAllStringIndex(text, -1) {
+		value := text[loc[0]:loc[1]]
+		if len(value) != 9 {
+			continue
+		}
+		// Must contain both letters and digits.
+		if !hasLetterAndDigit(value) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      value,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.70,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+
+	// Detect Dutch passports (2 letters + 7 alphanumeric = 9 chars).
+	for _, loc := range dutchPassportRe.FindAllStringIndex(text, -1) {
+		value := text[loc[0]:loc[1]]
+		// Must contain at least one digit to distinguish from plain words.
+		if !hasDigit(value) {
+			continue
+		}
+		// Skip if already matched as ID card (same value/position).
+		if isDuplicate(matches, loc[0], loc[1]) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.Passport,
+			Value:      value,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.70,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+
+	return matches, nil
+}
+
+func hasLetterAndDigit(s string) bool {
+	hasLetter, hasDigitVal := false, false
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			hasLetter = true
+		}
+		if r >= '0' && r <= '9' {
+			hasDigitVal = true
+		}
+	}
+	return hasLetter && hasDigitVal
+}
+
+func hasDigit(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func isDuplicate(matches []model.Match, start, end int) bool {
+	for _, m := range matches {
+		if m.Start == start && m.End == end {
+			return true
+		}
+	}
+	return false
+}

--- a/adapter/detector/nl/kvk.go
+++ b/adapter/detector/nl/kvk.go
@@ -1,0 +1,52 @@
+package nl
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// KvK number: 8-digit number.
+var kvkRe = regexp.MustCompile(`\b\d{8}\b`)
+
+// kvkPrefixRe matches common KvK prefixes that increase confidence.
+var kvkPrefixRe = regexp.MustCompile(`(?i)(?:kvk|kamer\s+van\s+koophandel)\s*[:.]?\s*$`)
+
+// KvKDetector detects Dutch Kamer van Koophandel (Chamber of Commerce) numbers.
+type KvKDetector struct{}
+
+func NewKvKDetector() *KvKDetector { return &KvKDetector{} }
+
+func (d *KvKDetector) Name() string              { return "nl/kvk" }
+func (d *KvKDetector) Locales() []string         { return []string{locale} }
+func (d *KvKDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *KvKDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := kvkRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	lower := strings.ToLower(text)
+	var matches []model.Match
+	for _, loc := range results {
+		confidence := 0.60
+		// Check for KvK prefix before the number to increase confidence.
+		prefix := lower[:loc[0]]
+		if kvkPrefixRe.MatchString(prefix) {
+			confidence = 0.90
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}

--- a/adapter/detector/nl/nl_test.go
+++ b/adapter/detector/nl/nl_test.go
@@ -1,0 +1,221 @@
+package nl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*BSNDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostalDetector)(nil)
+	_ port.Detector = (*KvKDetector)(nil)
+	_ port.Detector = (*IDDocumentDetector)(nil)
+)
+
+func TestBSNDetector(t *testing.T) {
+	d := NewBSNDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"BSN: 111222333", 1, "valid BSN plain"},
+		{"BSN: 111.222.333", 1, "valid BSN with dots"},
+		{"BSN: 111 222 333", 1, "valid BSN with spaces"},
+		{"123456782", 1, "valid 11-proof number"},
+		{"000000000", 0, "all zeros fails 11-proof (sum is 0)"},
+		{"123456789", 0, "invalid 11-proof"},
+		{"12345678", 0, "too few digits"},
+		{"no bsn here", 0, "no BSN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "nl" {
+				t.Errorf("expected locale 'nl', got %q", m.Locale)
+			}
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestBSN11Proof(t *testing.T) {
+	tests := []struct {
+		digits string
+		valid  bool
+		desc   string
+	}{
+		{"111222333", true, "known valid BSN"},
+		{"123456782", true, "another valid BSN"},
+		{"000000000", false, "all zeros (sum is 0)"},
+		{"123456789", false, "invalid checksum"},
+	}
+
+	for _, tt := range tests {
+		got := isValid11Proof(tt.digits)
+		if got != tt.valid {
+			t.Errorf("%s: isValid11Proof(%q) = %v, want %v", tt.desc, tt.digits, got, tt.valid)
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Bel 0612345678", 1, "mobile no separator"},
+		{"Bel 06-12345678", 1, "mobile with dash"},
+		{"Bel 06 12345678", 1, "mobile with space"},
+		{"+31 6 12345678", 1, "international mobile +31"},
+		{"0031 6 12345678", 1, "international mobile 0031"},
+		{"+31612345678", 1, "international mobile compact"},
+		{"020-1234567", 1, "landline Amsterdam"},
+		{"+31 20 1234567", 1, "international landline"},
+		{"0031 20 1234567", 1, "international landline 0031"},
+		{"12345", 0, "too short"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPostalDetector(t *testing.T) {
+	d := NewPostalDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"1234 AB", 1, "standard format with space"},
+		{"1234AB", 1, "no space"},
+		{"9999 ZZ", 1, "high number valid"},
+		{"1000 SA", 0, "SA excluded"},
+		{"1000 SD", 0, "SD excluded"},
+		{"1000 SS", 0, "SS excluded"},
+		{"0123 AB", 0, "starts with 0 invalid"},
+		{"1234 ab", 0, "lowercase invalid"},
+		{"no postal", 0, "no postal code"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+			if m.Confidence != 0.90 {
+				t.Errorf("expected confidence 0.90, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestKvKDetector(t *testing.T) {
+	d := NewKvKDetector()
+
+	tests := []struct {
+		input      string
+		want       int
+		desc       string
+		confidence float64
+	}{
+		{"12345678", 1, "bare 8-digit number", 0.60},
+		{"KvK 12345678", 1, "KvK prefix", 0.90},
+		{"kvk: 12345678", 1, "kvk lowercase with colon", 0.90},
+		{"Kamer van Koophandel 12345678", 1, "full name prefix", 0.90},
+		{"1234567", 0, "too few digits", 0},
+		{"123456789", 0, "too many digits", 0},
+		{"no kvk here", 0, "no KvK", 0},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+			if tt.confidence > 0 && m.Confidence != tt.confidence {
+				t.Errorf("%s: expected confidence %f, got %f", tt.desc, tt.confidence, m.Confidence)
+			}
+		}
+	}
+}
+
+func TestIDDocumentDetector(t *testing.T) {
+	d := NewIDDocumentDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"ID: SPECI2014", 1, "Dutch ID card format"},
+		{"ID: SPEC12014", 1, "Dutch ID alternate"},
+		{"PP: NR1234567", 1, "Dutch passport format"},
+		{"PP: AB1234567", 1, "Dutch passport alternate"},
+		{"ABCDEFGHI", 0, "all letters no digits"},
+		{"no id here", 0, "no ID document"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "nl" {
+				t.Errorf("expected locale 'nl', got %q", m.Locale)
+			}
+		}
+	}
+}

--- a/adapter/detector/nl/phone.go
+++ b/adapter/detector/nl/phone.go
@@ -1,0 +1,37 @@
+package nl
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Dutch phone number patterns:
+// Mobile: 06-XXXXXXXX, 06 XXXXXXXX, +31 6 XXXXXXXX, 0031 6 XXXXXXXX
+// Landline: 0XX-XXXXXXX, +31 XX XXXXXXX, 0031 XX XXXXXXX
+var phoneRe = regexp.MustCompile(
+	`(?:` +
+		// International prefix +31 or 0031 followed by mobile (6) or area code (1-5, 7)
+		`(?:\+31|0031)[\s\-]?(?:6[\s\-]?\d{8}|[1-57]\d[\s\-]?\d{7})` +
+		`|` +
+		// Domestic mobile: 06 followed by 8 digits
+		`\b06[\s\-]?\d{8}` +
+		`|` +
+		// Domestic landline: 0 + 2-digit area code + 7-digit subscriber
+		`\b0[1-57]\d[\s\-]?\d{7}` +
+		`)(?:\b|$)`,
+)
+
+// PhoneDetector detects Dutch phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "nl/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(phoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/nl/postal.go
+++ b/adapter/detector/nl/postal.go
@@ -1,0 +1,57 @@
+package nl
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Dutch postal code: 4 digits + optional space + 2 uppercase letters.
+// First digit cannot be 0.
+var postalRe = regexp.MustCompile(`\b[1-9]\d{3}\s?[A-Z]{2}\b`)
+
+// invalidLetterCombos contains letter combinations not used in Dutch postal codes.
+var invalidLetterCombos = map[string]bool{
+	"SA": true,
+	"SD": true,
+	"SS": true,
+}
+
+// PostalDetector detects Dutch postal codes.
+type PostalDetector struct{}
+
+func NewPostalDetector() *PostalDetector { return &PostalDetector{} }
+
+func (d *PostalDetector) Name() string              { return "nl/postal" }
+func (d *PostalDetector) Locales() []string         { return []string{locale} }
+func (d *PostalDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostalDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := postalRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		value := text[loc[0]:loc[1]]
+		// Extract the 2-letter suffix.
+		letters := strings.TrimSpace(value)
+		letterPart := letters[len(letters)-2:]
+		if invalidLetterCombos[letterPart] {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.PostalCode,
+			Value:      value,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}


### PR DESCRIPTION
## Summary
- Implements issue #9: Netherlands-specific PII detectors
- BSN with 11-proof checksum validation
- Dutch phone numbers (mobile, landline, international formats)
- Postal codes with invalid letter combo exclusion
- KvK numbers with context-aware confidence
- Dutch ID/Passport document numbers

Closes #9

## Test plan
- [ ] `go test ./adapter/detector/nl/...` passes
- [ ] All detectors implement `port.Detector` interface
- [ ] BSN 11-proof validation rejects invalid numbers
- [ ] Phone detector handles +31, 06, and landline formats