### PR TITLE
feat: add France PII detectors -- NIR, NIF, phone, code postal, CNI

### DIFF
--- a/adapter/detector/fr/fr_test.go
+++ b/adapter/detector/fr/fr_test.go
@@ -1,0 +1,194 @@
+package fr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*NIRDetector)(nil)
+	_ port.Detector = (*NIFDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostalDetector)(nil)
+	_ port.Detector = (*IDCardDetector)(nil)
+)
+
+func TestNIRDetector(t *testing.T) {
+	d := NewNIRDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		// key = 97 - (2840578006084 % 97) = 90.
+		{"NIR: 2 84 05 78 006 084 90", 1, "valid NIR with spaces"},
+		{"284057800608490", 1, "valid NIR without spaces"},
+		// Invalid control key.
+		{"2 84 05 78 006 084 99", 0, "invalid control key"},
+		// Corsica 2A: key = 97 - ((1850120033084 - 1000000) % 97) = 34.
+		{"1 85 01 2A 033 084 34", 1, "valid NIR Corsica 2A"},
+		// Corsica 2B: key = 97 - ((2900320001002 - 2000000) % 97) = 64.
+		{"2 90 03 2B 001 002 64", 1, "valid NIR Corsica 2B"},
+		{"no nir here", 0, "no NIR"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "fr" {
+				t.Errorf("expected locale 'fr', got %q", m.Locale)
+			}
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestNIFDetector(t *testing.T) {
+	d := NewNIFDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"NIF: 0123456789012", 1, "valid NIF starting with 0"},
+		{"1234567890123", 1, "valid NIF starting with 1"},
+		{"32 99 123 456 789", 1, "formatted NIF"},
+		{"4123456789012", 0, "invalid first digit 4"},
+		{"9123456789012", 0, "invalid first digit 9"},
+		{"no nif here", 0, "no NIF"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Tel: 06 12 34 56 78", 1, "mobile 06 with spaces"},
+		{"07.12.34.56.78", 1, "mobile 07 with dots"},
+		{"01 23 45 67 89", 1, "landline 01"},
+		{"02-34-56-78-90", 1, "landline 02 with dashes"},
+		{"0345678901", 1, "landline 03 no separators"},
+		{"04 56 78 90 12", 1, "landline 04"},
+		{"05 67 89 01 23", 1, "landline 05"},
+		{"+33 6 12 34 56 78", 1, "international mobile +33 6"},
+		{"+33 7 12 34 56 78", 1, "international mobile +33 7"},
+		{"+33 1 23 45 67 89", 1, "international landline +33 1"},
+		{"+33.5.67.89.01.23", 1, "international with dots"},
+		{"08 12 34 56 78", 0, "08 prefix not matched"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPostalDetector(t *testing.T) {
+	d := NewPostalDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Code postal: 75001", 1, "Paris 1er"},
+		{"13100", 1, "Aix-en-Provence"},
+		{"97400", 1, "DOM department 97"},
+		{"98000", 1, "department 98"},
+		{"00123", 0, "invalid department 00"},
+		{"96000", 0, "invalid department 96"},
+		{"99000", 0, "invalid department 99"},
+		{"no postal", 0, "no postal code"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestIDCardDetector(t *testing.T) {
+	d := NewIDCardDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"CNI: 880123456789", 1, "old format 12 digits"},
+		{"CNI: F4R7X2K9Q", 1, "new format 9 alphanumeric"},
+		{"AB12CD345", 1, "new format mixed"},
+		{"no cni here", 0, "no CNI"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+		}
+	}
+}

--- a/adapter/detector/fr/helpers.go
+++ b/adapter/detector/fr/helpers.go
@@ -1,0 +1,31 @@
+// Package fr provides PII detectors for France-specific patterns.
+package fr
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "fr"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/fr/id_card.go
+++ b/adapter/detector/fr/id_card.go
@@ -1,0 +1,35 @@
+package fr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// CNI (Carte Nationale d'Identite):
+//   - Old format (before 2021): 12 digits
+//   - New format (since 2021): 9 alphanumeric characters
+var (
+	cniOldRe = regexp.MustCompile(`\b\d{12}\b`)
+	cniNewRe = regexp.MustCompile(`\b[A-Z0-9]{9}\b`)
+)
+
+// IDCardDetector detects French CNI (national identity card) numbers.
+type IDCardDetector struct{}
+
+func NewIDCardDetector() *IDCardDetector { return &IDCardDetector{} }
+
+func (d *IDCardDetector) Name() string              { return "fr/id_card" }
+func (d *IDCardDetector) Locales() []string         { return []string{locale} }
+func (d *IDCardDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *IDCardDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	var matches []model.Match
+	matches = append(matches, findAll(cniOldRe, text, model.NationalID, 0.65, d.Name())...)
+	matches = append(matches, findAll(cniNewRe, text, model.NationalID, 0.65, d.Name())...)
+
+	// Deduplicate: old-format 12-digit matches may overlap with new-format 9-char matches.
+	// Since old-format is strictly digits and 12 chars, and new is 9 chars, no real overlap.
+	return matches, nil
+}

--- a/adapter/detector/fr/nif.go
+++ b/adapter/detector/fr/nif.go
@@ -1,0 +1,25 @@
+package fr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// NIF (Numero d'Identification Fiscale) — 13 digits, first digit 0-3.
+// Matches bare 13-digit strings or formatted XX XX XXX XXX XXX.
+var nifRe = regexp.MustCompile(`\b[0-3]\d[\s.-]?\d{2}[\s.-]?\d{3}[\s.-]?\d{3}[\s.-]?\d{3}\b`)
+
+// NIFDetector detects French tax identification numbers.
+type NIFDetector struct{}
+
+func NewNIFDetector() *NIFDetector { return &NIFDetector{} }
+
+func (d *NIFDetector) Name() string              { return "fr/nif" }
+func (d *NIFDetector) Locales() []string         { return []string{locale} }
+func (d *NIFDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *NIFDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(nifRe, text, model.TaxID, 0.70, d.Name()), nil
+}

--- a/adapter/detector/fr/nir.go
+++ b/adapter/detector/fr/nir.go
@@ -1,0 +1,120 @@
+package fr
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// NIR (Numero d'Inscription au Repertoire) / Numero de securite sociale.
+// Format: X XX XX XXXXX XXX XX (15 digits, with Corsica departments 2A/2B).
+// Matches with or without spaces/dashes/dots as separators.
+var nirRe = regexp.MustCompile(
+	`\b([12])\s?(\d{2})\s?(0[1-9]|1[0-2]|[2-9]\d)\s?` +
+		`(\d{2}|2[AB])\s?(\d{3})\s?(\d{3})\s?(\d{2})\b`,
+)
+
+// NIRDetector detects French NIR (social security) numbers.
+type NIRDetector struct{}
+
+func NewNIRDetector() *NIRDetector { return &NIRDetector{} }
+
+func (d *NIRDetector) Name() string              { return "fr/nir" }
+func (d *NIRDetector) Locales() []string         { return []string{locale} }
+func (d *NIRDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *NIRDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := nirRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		full := text[loc[0]:loc[1]]
+		dept := text[loc[8]:loc[9]] // group 4: department
+
+		// Build the 13-digit numeric base for key validation.
+		// For Corsica, replace 2A with 19 and 2B with 18 before computing.
+		digits := stripSeparators(full)
+		base13 := digits[:13]
+		keyStr := digits[13:15]
+
+		key, err := strconv.Atoi(keyStr)
+		if err != nil {
+			continue
+		}
+
+		numBase, ok := nirBaseNumber(base13, dept)
+		if !ok {
+			continue
+		}
+
+		// Control key = 97 - (first 13 digits mod 97).
+		expectedKey := 97 - int(numBase%97)
+		if key != expectedKey {
+			continue
+		}
+
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      full,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// stripSeparators removes spaces, dashes, and dots from a NIR string,
+// and replaces 2A/2B with placeholder digits for numeric parsing.
+func stripSeparators(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == 'A' || r == 'a':
+			b.WriteRune('A')
+		case r == 'B' || r == 'b':
+			b.WriteRune('B')
+		}
+	}
+	return b.String()
+}
+
+// nirBaseNumber converts the 13-character base (which may contain A or B for
+// Corsica departments) into a numeric value suitable for mod-97 computation.
+// For Corsica: 2A -> subtract 1000000 from numeric value with 20 replacing 2A,
+//
+//	2B -> subtract 2000000 from numeric value with 20 replacing 2B.
+func nirBaseNumber(base13 string, dept string) (int64, bool) {
+	switch strings.ToUpper(dept) {
+	case "2A":
+		numeric := strings.Replace(base13, "A", "0", 1) // 2A -> 20
+		n, err := strconv.ParseInt(numeric, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n - 1000000, true
+	case "2B":
+		numeric := strings.Replace(base13, "B", "0", 1) // 2B -> 20
+		n, err := strconv.ParseInt(numeric, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n - 2000000, true
+	default:
+		n, err := strconv.ParseInt(base13, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+}

--- a/adapter/detector/fr/phone.go
+++ b/adapter/detector/fr/phone.go
@@ -1,0 +1,32 @@
+package fr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// French phone numbers:
+//   - Local format: 0X XX XX XX XX (X = 1-7 for landline/mobile)
+//   - International: +33 X XX XX XX XX
+//
+// Separators: space, dot, dash, or none.
+var phoneRe = regexp.MustCompile(
+	`(?:` +
+		`(?:\+33[\s.-]?|0)[1-7][\s.-]?\d{2}[\s.-]?\d{2}[\s.-]?\d{2}[\s.-]?\d{2}` +
+		`)\b`,
+)
+
+// PhoneDetector detects French phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "fr/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(phoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/fr/postal.go
+++ b/adapter/detector/fr/postal.go
@@ -1,0 +1,53 @@
+package fr
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Code postal: 5 digits, first 2 = department (01-95, 97, 98).
+var postalRe = regexp.MustCompile(`\b(\d{2})\d{3}\b`)
+
+// PostalDetector detects French postal codes.
+type PostalDetector struct{}
+
+func NewPostalDetector() *PostalDetector { return &PostalDetector{} }
+
+func (d *PostalDetector) Name() string              { return "fr/postal" }
+func (d *PostalDetector) Locales() []string         { return []string{locale} }
+func (d *PostalDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostalDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := postalRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		dept := text[loc[2]:loc[3]]
+		deptNum, err := strconv.Atoi(dept)
+		if err != nil {
+			continue
+		}
+
+		// Valid department prefixes: 01-95, 97, 98.
+		if deptNum < 1 || deptNum > 98 || deptNum == 96 {
+			continue
+		}
+
+		matches = append(matches, model.Match{
+			Type:       model.PostalCode,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.60,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}


### PR DESCRIPTION
## Summary
- Implements issue #13: France-specific PII detectors
- NIR (numero de securite sociale) with mod-97 control key validation
- NIF (tax number) detection
- French phone numbers (mobile 06/07, landline 01-05, international +33)
- Code postal with department validation
- CNI (carte nationale d'identite) old and new formats

Closes #13

## Test plan
- [ ] `go test ./adapter/detector/fr/...` passes
- [ ] All detectors implement `port.Detector` interface
- [ ] NIR control key validation works (including Corsica 2A/2B)
- [ ] Phone detector handles all French formats