### PR TITLE
docs: add CITATION.cff for academic citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+title: "wuming: A Global PII Detection and Redaction Library"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - name: "taoq-ai"
+    website: "https://github.com/taoq-ai"
+repository-code: "https://github.com/taoq-ai/wuming"
+url: "https://taoq-ai.github.io/wuming"
+abstract: >-
+  wuming (无名, "The Nameless") is a Go library for detecting and removing
+  Personally Identifiable Information (PII) from text. It supports global
+  standards across multiple locales including US, EU, NL, GB, DE, FR, and
+  more, using a hexagonal architecture for extensibility and testability.
+keywords:
+  - PII
+  - deidentification
+  - privacy
+  - GDPR
+  - data-protection
+  - Go
+  - redaction
+  - anonymization
+license: MIT
+version: 0.2.0
+date-released: "2026-03-19"


### PR DESCRIPTION
## Summary
- Adds CITATION.cff following the Citation File Format standard
- Enables GitHub's "Cite this repository" button in the sidebar
- Includes keywords for discoverability: PII, deidentification, privacy, GDPR

Closes #26

## Test plan
- [ ] GitHub shows "Cite this repository" button after merge
- [ ] CFF format validates (keys match CFF 1.2.0 spec)