### PR TITLE
docs: add README, CONTRIBUTING, ARCHITECTURE, SECURITY, and examples

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,129 @@
+# Architecture
+
+Wuming uses a **hexagonal architecture** (also known as ports & adapters) to keep the core domain logic independent of concrete implementations. This makes the library easy to test, extend, and maintain.
+
+## Layers
+
+```
+┌─────────────────────────────────────┐
+│         Public API (wuming.go)      │
+├─────────────────────────────────────┤
+│         Internal Engine             │
+├──────────┬──────────────────────────┤
+│  Ports   │  domain/port/            │
+│          │  - Detector interface    │
+│          │  - Replacer interface    │
+│          │  - Pipeline interface    │
+├──────────┼──────────────────────────┤
+│  Domain  │  domain/model/           │
+│          │  - PIIType, Match        │
+│          │  - Severity              │
+├──────────┼──────────────────────────┤
+│ Adapters │  adapter/detector/{loc}  │
+│          │  adapter/replacer/       │
+└──────────┴──────────────────────────┘
+```
+
+### Public API
+
+**Package:** `wuming` (root)
+
+The top-level package provides the user-facing API. It exposes the `Wuming` struct and functional options (`WithDetectors`, `WithReplacer`, `WithLocale`, etc.) that configure the internal engine. Users never interact with the engine directly.
+
+Key methods:
+- `Process(ctx, text)` — detect and replace, returning the full result
+- `Detect(ctx, text)` — detect only, returning matches
+- `Redact(ctx, text)` — detect and replace, returning just the redacted string
+
+### Internal Engine
+
+**Package:** `internal/engine`
+
+The engine is the orchestrator. It receives a list of detectors and a replacer, runs detection (optionally in parallel), deduplicates overlapping matches, and applies the replacer. It implements the `port.Pipeline` interface.
+
+The engine is internal — it cannot be imported by external packages. All access goes through the public API.
+
+### Ports (Interfaces)
+
+**Package:** `domain/port`
+
+Ports define the contracts that adapters must satisfy. There are three interfaces:
+
+- **Detector** — scans text and returns PII matches. Each detector declares its name, supported locales, and PII types.
+- **Replacer** — takes text and matches, returns text with PII substituted.
+- **Pipeline** — orchestrates detection and replacement (implemented by the engine).
+
+The `Result` struct also lives here, containing the original text, redacted text, matches, and match count.
+
+### Domain Model
+
+**Package:** `domain/model`
+
+Pure domain types with no dependencies:
+
+- **PIIType** — enumeration of PII categories (Email, Phone, CreditCard, NationalID, TaxID, etc.)
+- **Match** — a single detection result with type, value, byte offsets, confidence score, locale, and detector name
+- **Severity** — sensitivity level (Low, Medium, High, Critical)
+
+### Adapters
+
+**Packages:** `adapter/detector/*`, `adapter/replacer/`
+
+Concrete implementations of the port interfaces.
+
+**Detectors** are organized by locale:
+- `adapter/detector/common` — locale-independent patterns (email, credit card, IBAN, IP, URL, MAC)
+- `adapter/detector/us` — United States (SSN, ITIN, EIN, phone, ZIP, passport, Medicare)
+- `adapter/detector/nl` — Netherlands (BSN, phone, postal, KvK, ID document)
+- `adapter/detector/eu` — European Union (VAT, passport MRZ)
+- `adapter/detector/gb` — United Kingdom (NIN, NHS, UTR, phone, postcode)
+- `adapter/detector/de` — Germany (Steuer-ID, Sozialversicherungsnummer, phone, PLZ, ID card)
+- `adapter/detector/fr` — France (NIR, NIF, phone, postal, ID card)
+
+**Replacers** provide different substitution strategies:
+- `Redact` — type-based placeholder (e.g., `[EMAIL]`)
+- `Mask` — character masking with preserved suffix
+- `Hash` — deterministic SHA-256 hash
+- `Custom` — user-defined function
+
+## Data Flow
+
+```
+Input text
+    │
+    ▼
+┌──────────┐
+│  Engine   │──── Filters detectors by locale
+│           │
+│  ┌───────────────────────────────────┐
+│  │  Detector 1 ──┐                   │
+│  │  Detector 2 ──┼── (concurrent)    │
+│  │  Detector N ──┘                   │
+│  └───────────────────────────────────┘
+│           │
+│  Filter by confidence threshold
+│  Filter by PII type
+│  Deduplicate overlapping matches
+│           │
+│  ┌──────────────┐
+│  │   Replacer   │── Substitutes matches in text
+│  └──────────────┘
+│           │
+└──────────┘
+    │
+    ▼
+Result { Original, Redacted, Matches, MatchCount }
+```
+
+1. The engine selects active detectors based on configured locale filters. Global detectors (those with no locale) always run.
+2. Detectors run concurrently (bounded by the concurrency setting). Each returns a slice of `Match` values.
+3. The engine filters matches by confidence threshold and PII type, then deduplicates overlapping matches (keeping the higher-confidence one).
+4. The replacer walks the matches and substitutes each one in the original text.
+5. The result is returned with the original text, redacted text, all matches, and a match count.
+
+## Why Hexagonal Architecture?
+
+- **Testability** — detectors and replacers can be tested in isolation with simple unit tests. The engine can be tested with mock implementations.
+- **Extensibility** — adding a new locale means creating a new package under `adapter/detector/` without modifying any existing code.
+- **Locale isolation** — each locale's detection logic is self-contained. A bug in the Dutch BSN detector cannot affect the US SSN detector.
+- **Replacer flexibility** — swapping between redaction strategies is a single option change; no detection logic needs to change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,199 @@
+# Contributing to wuming
+
+Thank you for your interest in contributing to wuming. This guide covers everything you need to get started.
+
+## Development Setup
+
+### Prerequisites
+
+- **Go 1.22** or later
+- **golangci-lint** (for linting)
+
+### Getting Started
+
+```sh
+git clone https://github.com/taoq-ai/wuming.git
+cd wuming
+make test
+```
+
+### Useful Make Targets
+
+| Command      | Description                       |
+|--------------|-----------------------------------|
+| `make build` | Build all packages                |
+| `make test`  | Run tests with race detection     |
+| `make lint`  | Run golangci-lint                 |
+| `make fmt`   | Format code with gofmt            |
+| `make vet`   | Run go vet                        |
+| `make check` | Run fmt, vet, test, and lint      |
+
+## How to Add a New Locale Detector
+
+Each locale lives in its own package under `adapter/detector/`. Follow these steps to add a new locale (for example, `jp` for Japan):
+
+### 1. Create the package directory
+
+```sh
+mkdir -p adapter/detector/jp
+```
+
+### 2. Create a helpers file
+
+Create `adapter/detector/jp/helpers.go` with shared utilities:
+
+```go
+package jp
+
+import (
+    "context"
+    "regexp"
+
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "jp"
+
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+    results := re.FindAllStringIndex(text, -1)
+    if len(results) == 0 {
+        return nil
+    }
+
+    var matches []model.Match
+    for _, loc := range results {
+        matches = append(matches, model.Match{
+            Type:       piiType,
+            Value:      text[loc[0]:loc[1]],
+            Start:      loc[0],
+            End:        loc[1],
+            Confidence: confidence,
+            Locale:     locale,
+            Detector:   detector,
+        })
+    }
+    return matches
+}
+```
+
+### 3. Create a detector
+
+Create `adapter/detector/jp/my_number.go`:
+
+```go
+package jp
+
+import (
+    "context"
+    "regexp"
+
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+var myNumberRe = regexp.MustCompile(`\b\d{4}\s?\d{4}\s?\d{4}\b`)
+
+// MyNumberDetector detects Japanese My Number (Individual Number).
+type MyNumberDetector struct{}
+
+func NewMyNumberDetector() *MyNumberDetector { return &MyNumberDetector{} }
+
+func (d *MyNumberDetector) Name() string              { return "jp/my_number" }
+func (d *MyNumberDetector) Locales() []string         { return []string{locale} }
+func (d *MyNumberDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *MyNumberDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+    return findAll(myNumberRe, text, model.NationalID, 0.85, d.Name()), nil
+}
+```
+
+### 4. Write tests
+
+Create `adapter/detector/jp/jp_test.go` using table-driven tests:
+
+```go
+package jp
+
+import (
+    "context"
+    "testing"
+
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+func TestMyNumberDetector(t *testing.T) {
+    d := NewMyNumberDetector()
+
+    tests := []struct {
+        name  string
+        input string
+        want  int
+    }{
+        {"valid my number", "My number is 1234 5678 9012", 1},
+        {"no match", "Hello world", 0},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            matches, err := d.Detect(context.Background(), tt.input)
+            if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+            if len(matches) != tt.want {
+                t.Errorf("got %d matches, want %d", len(matches), tt.want)
+            }
+        })
+    }
+}
+```
+
+### 5. Verify the interface
+
+Ensure your detector satisfies the `port.Detector` interface by adding a compile-time check at the top of your detector file:
+
+```go
+var _ port.Detector = (*MyNumberDetector)(nil)
+```
+
+## How to Add a New Replacer
+
+Replacers live in `adapter/replacer/`. To add one:
+
+1. Create a new file in `adapter/replacer/` (e.g., `anonymize.go`).
+2. Implement the `port.Replacer` interface:
+   - `Replace(text string, matches []model.Match) (string, error)`
+   - `Name() string`
+3. Add a constructor function (e.g., `NewAnonymize()`).
+4. Write tests in `adapter/replacer/replacer_test.go` or a new test file.
+5. Add a compile-time interface check: `var _ port.Replacer = (*Anonymize)(nil)`
+
+## Code Style
+
+- Run `gofmt` on all code before committing.
+- Run `golangci-lint run ./...` and fix any issues.
+- Follow standard Go conventions: exported names have GoDoc comments, packages have doc comments.
+- Keep functions focused and small.
+
+## PR Workflow
+
+1. **Branch from `main`** — create a feature branch with a descriptive name (e.g., `feat/jp-detectors`).
+2. **One feature per PR** — keep pull requests focused on a single change.
+3. **Use conventional commits** — prefix commit messages with a type:
+   - `feat:` for new features
+   - `fix:` for bug fixes
+   - `docs:` for documentation
+   - `test:` for test additions or changes
+   - `refactor:` for refactoring
+   - `chore:` for maintenance tasks
+4. **Ensure CI passes** — `make check` should succeed before opening a PR.
+5. **Write a clear PR description** — explain what the change does and why.
+
+## Testing Expectations
+
+- Use **table-driven tests** for detector and replacer tests.
+- Include both positive matches and negative (no-match) cases.
+- Add **interface compliance checks** at compile time:
+  ```go
+  var _ port.Detector = (*MyDetector)(nil)
+  ```
+- Run tests with race detection: `go test -race ./...`
+- Aim for meaningful coverage of edge cases, not just line coverage.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# 无名 wuming
+
+> **The Nameless** — A Go library for detecting and removing PII from text
+
+*"The nameless (无名) is the origin of heaven and earth"* — Tao Te Ching, Chapter 1
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/taoq-ai/wuming.svg)](https://pkg.go.dev/github.com/taoq-ai/wuming)
+[![Go Report Card](https://goreportcard.com/badge/github.com/taoq-ai/wuming)](https://goreportcard.com/report/github.com/taoq-ai/wuming)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/taoq-ai/wuming/actions/workflows/ci.yml/badge.svg)](https://github.com/taoq-ai/wuming/actions/workflows/ci.yml)
+
+---
+
+## Features
+
+- **Hexagonal architecture** — clean separation between domain logic, ports, and adapters
+- **Global coverage** — detectors for common patterns (email, credit card, IBAN) plus locale-specific PII (US SSN, Dutch BSN, UK NIN, German Steuer-ID, French NIR, EU VAT)
+- **Pluggable replacers** — redact, mask, hash, or bring your own replacement strategy
+- **Concurrent detection** — run multiple detectors in parallel with configurable concurrency
+- **Confidence scoring** — every match includes a confidence score; filter by threshold
+- **Zero dependencies** — pure Go standard library, no external modules
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/taoq-ai/wuming"
+    "github.com/taoq-ai/wuming/adapter/detector/common"
+    "github.com/taoq-ai/wuming/adapter/detector/nl"
+)
+
+func main() {
+    w := wuming.New(
+        wuming.WithDetectors(
+            common.NewEmailDetector(),
+            nl.NewPhoneDetector(),
+        ),
+    )
+
+    result, err := w.Process(context.Background(), "Call me at 06-12345678 or email john@example.com")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(result.Redacted)
+    // Output: Call me at [PHONE] or email [EMAIL]
+}
+```
+
+## Installation
+
+```sh
+go get github.com/taoq-ai/wuming
+```
+
+Requires **Go 1.22** or later.
+
+## Supported Locales
+
+| Locale   | Package                          | Key Patterns                                              |
+|----------|----------------------------------|-----------------------------------------------------------|
+| common   | `adapter/detector/common`        | Email, Credit Card, IBAN, IP Address, URL, MAC Address    |
+| us       | `adapter/detector/us`            | SSN, ITIN, EIN, Phone, ZIP, Passport, Medicare            |
+| nl       | `adapter/detector/nl`            | BSN, Phone, Postal Code, KvK Number, ID Document          |
+| eu       | `adapter/detector/eu`            | VAT Number, Passport MRZ                                  |
+| gb       | `adapter/detector/gb`            | NIN, NHS Number, UTR, Phone, Postcode                     |
+| de       | `adapter/detector/de`            | Steuer-ID, Sozialversicherungsnummer, Phone, PLZ, ID Card |
+| fr       | `adapter/detector/fr`            | NIR, NIF, Phone, Postal Code, ID Card                     |
+
+## Replacer Strategies
+
+| Strategy | Type                    | Description                                        | Example Output          |
+|----------|-------------------------|----------------------------------------------------|-------------------------|
+| Redact   | `replacer.NewRedact()`  | Replace with type placeholder                      | `[EMAIL]`               |
+| Mask     | `replacer.NewMask()`    | Mask characters, preserve last N                   | `****5678`              |
+| Hash     | `replacer.NewHash()`    | Deterministic SHA-256 hash (truncated)             | `a1b2c3d4e5f67890`     |
+| Custom   | `replacer.NewCustom(…)` | User-defined replacement function                  | *(anything you want)*   |
+
+```go
+// Use a mask replacer instead of the default redact
+w := wuming.New(
+    wuming.WithDetectors(common.NewEmailDetector()),
+    wuming.WithReplacer(replacer.NewMask()),
+)
+```
+
+## Architecture
+
+Wuming follows a hexagonal (ports & adapters) architecture:
+
+```
+┌─────────────────────────────────────┐
+│         Public API (wuming.go)      │
+├─────────────────────────────────────┤
+│         Internal Engine             │
+├──────────┬──────────────────────────┤
+│  Ports   │  domain/port/            │
+│          │  - Detector interface    │
+│          │  - Replacer interface    │
+│          │  - Pipeline interface    │
+├──────────┼──────────────────────────┤
+│  Domain  │  domain/model/           │
+│          │  - PIIType, Match        │
+│          │  - Severity              │
+├──────────┼──────────────────────────┤
+│ Adapters │  adapter/detector/{loc}  │
+│          │  adapter/replacer/       │
+└──────────┴──────────────────────────┘
+```
+
+The public API delegates to an internal engine that orchestrates detectors (through the `port.Detector` interface) and replacers (through the `port.Replacer` interface). Each locale lives in its own adapter package, making it straightforward to add new locales without touching existing code.
+
+For a deeper dive, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and how to add new detectors.
+
+## Security
+
+For responsible disclosure of security issues, see [SECURITY.md](SECURITY.md).
+
+## License
+
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in wuming, please report it responsibly.
+
+**Contact:** security@taoq.ai
+
+Alternatively, you can use [GitHub Security Advisories](https://github.com/taoq-ai/wuming/security/advisories/new) to report vulnerabilities privately.
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+## What Counts as a Security Issue
+
+- Regular expression denial of service (ReDoS) in any detector pattern
+- Incorrect redaction that leaks PII (e.g., partial replacement, off-by-one in byte offsets)
+- Panics or crashes caused by crafted input
+- Information leakage through error messages
+
+## What Is Not a Security Issue
+
+- Feature requests for new PII types or locales
+- False positives or false negatives in detection (these are bugs, not security issues)
+- Performance issues
+
+## Response Timeline
+
+- **Acknowledgment:** within 3 business days
+- **Initial assessment:** within 7 business days
+- **Fix or mitigation:** best effort, typically within 30 days for confirmed vulnerabilities
+
+## Important Note
+
+This library processes text entirely in-process. It makes **no network calls**, stores **no data**, and has **no external dependencies**. The attack surface is limited to the input text provided by the caller.

--- a/_examples/basic/go.mod
+++ b/_examples/basic/go.mod
@@ -1,0 +1,7 @@
+module github.com/taoq-ai/wuming/_examples/basic
+
+go 1.22
+
+require github.com/taoq-ai/wuming v0.0.0
+
+replace github.com/taoq-ai/wuming => ../..

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/taoq-ai/wuming"
+	"github.com/taoq-ai/wuming/adapter/detector/common"
+	"github.com/taoq-ai/wuming/adapter/detector/nl"
+	"github.com/taoq-ai/wuming/adapter/detector/us"
+)
+
+func main() {
+	// Create a wuming instance with detectors from multiple locales.
+	w := wuming.New(
+		wuming.WithDetectors(
+			common.NewEmailDetector(),
+			common.NewCreditCardDetector(),
+			us.NewSSNDetector(),
+			nl.NewBSNDetector(),
+			nl.NewPhoneDetector(),
+		),
+	)
+
+	text := "Email john@acme.com, SSN 123-45-6789, BSN 111222333, call 06-12345678"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Original:", result.Original)
+	fmt.Println("Redacted:", result.Redacted)
+	fmt.Printf("Found %d PII matches\n", result.MatchCount)
+	for _, m := range result.Matches {
+		fmt.Printf("  [%s] %q (confidence: %.0f%%)\n", m.Type, m.Value, m.Confidence*100)
+	}
+}


### PR DESCRIPTION
## Summary
- Comprehensive README with badges, quick start, locale table, and architecture overview
- CONTRIBUTING.md with step-by-step guide for adding new detectors
- ARCHITECTURE.md explaining hexagonal design with ASCII diagrams
- SECURITY.md with responsible disclosure policy
- Runnable example in `_examples/basic/`

Closes #23

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Example compiles: `cd _examples/basic && go build .`
- [ ] All links in docs are valid