### PR TITLE
docs: add MkDocs site with Material theme and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: docs
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -1,0 +1,87 @@
+# Hexagonal Design
+
+wuming is built on a hexagonal architecture that separates domain logic from concrete implementations through well-defined port interfaces.
+
+## Architecture Diagram
+
+```mermaid
+graph TB
+    API[Public API - wuming.go] --> Engine[Internal Engine]
+    Engine --> DetPort[Detector Port]
+    Engine --> RepPort[Replacer Port]
+    DetPort --> Common[Common Detectors]
+    DetPort --> US[US Detectors]
+    DetPort --> NL[NL Detectors]
+    DetPort --> EU[EU Detectors]
+    DetPort --> GB[GB Detectors]
+    DetPort --> DE[DE Detectors]
+    DetPort --> FR[FR Detectors]
+    RepPort --> Redact[Redact]
+    RepPort --> Mask[Mask]
+    RepPort --> Hash[Hash]
+```
+
+## Layers
+
+### Domain Layer (`domain/`)
+
+The domain layer defines the core types and interfaces that the rest of the system depends on. It has zero external dependencies.
+
+- **`model.PIIType`** -- Enumeration of all PII categories (Email, Phone, CreditCard, IBAN, NationalID, TaxID, etc.)
+- **`model.Match`** -- Represents a single PII detection: type, value, position, confidence, locale, and detector name.
+- **`model.Severity`** -- Classification of how sensitive a PII type is (Low, Medium, High, Critical).
+- **`port.Detector`** -- Interface that all detectors implement: `Detect(ctx, text)`, `Name()`, `Locales()`, `PIITypes()`.
+- **`port.Replacer`** -- Interface that all replacers implement: `Replace(text, matches)`, `Name()`.
+
+### Internal Layer (`internal/engine/`)
+
+The engine is the orchestrator. It is internal to the module and not part of the public API. It:
+
+- Selects detectors based on locale configuration
+- Runs detectors concurrently with a semaphore for concurrency control
+- Merges results and resolves overlapping matches (preferring higher confidence)
+- Applies confidence and PII type filters
+- Delegates replacement to the configured replacer
+
+### Adapter Layer (`adapter/`)
+
+Adapters are the concrete implementations of the port interfaces.
+
+**Detectors** are organized by locale:
+
+| Package | Locale | Detectors |
+|---------|--------|-----------|
+| `common` | Global (all locales) | Email, Credit Card, IBAN, IP Address, URL, MAC Address |
+| `us` | United States | SSN, EIN, ITIN, Phone, Passport, ZIP Code, Medicare |
+| `nl` | Netherlands | BSN, Phone, Postal Code, KvK, ID Documents |
+| `eu` | European Union | VAT Number, Passport MRZ |
+| `gb` | United Kingdom | NIN, NHS Number, UTR, Phone, Postcode |
+| `de` | Germany | Steuer-ID, ID Card, Sozialversicherung, Phone, PLZ |
+| `fr` | France | NIR, NIF, ID Card, Phone, Postal Code |
+
+**Replacers** provide different substitution strategies:
+
+| Replacer | Behavior |
+|----------|----------|
+| Redact | Replaces with `[TYPE]` placeholder |
+| Mask | Masks characters with `*`, preserving last N |
+| Hash | Deterministic SHA-256 hash (truncated) |
+| Custom | User-defined replacement function |
+
+## Why Hexagonal?
+
+### Testability
+
+Each detector is independently testable. The engine can be tested with mock detectors and replacers. No integration test needs real PII data.
+
+### Extensibility
+
+Adding a new locale means creating a new package under `adapter/detector/` and implementing the `Detector` interface. No existing code needs to change.
+
+### Locale Isolation
+
+Each locale's detection logic is fully contained in its own package. Dutch BSN validation (11-proof) lives in `adapter/detector/nl/`, completely independent from US SSN validation. This prevents accidental cross-locale interference and makes regulatory compliance easier to verify.
+
+### Pluggable Strategies
+
+The replacer port allows callers to choose or implement any substitution strategy without modifying the detection pipeline. The same set of matches can be redacted, masked, hashed, or transformed by custom logic.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,57 @@
+# Architecture Overview
+
+wuming follows a **hexagonal architecture** (also known as ports and adapters) to keep the core domain logic independent of specific PII detection implementations. This enables easy extension, testing, and locale isolation.
+
+## High-Level Data Flow
+
+```mermaid
+graph LR
+    Input[Input Text] --> API[wuming.Process]
+    API --> Engine[Engine]
+    Engine --> D1[Detector 1]
+    Engine --> D2[Detector 2]
+    Engine --> DN[Detector N]
+    D1 --> Merge[Merge & Dedup]
+    D2 --> Merge
+    DN --> Merge
+    Merge --> Filter[Filter by Confidence & Type]
+    Filter --> Replacer[Replacer]
+    Replacer --> Output[Redacted Text + Matches]
+```
+
+## Package Structure
+
+```
+wuming/
+  wuming.go                 # Public API (New, Process, Detect, Redact)
+  domain/
+    model/pii.go            # Core types: PIIType, Match, Severity
+    port/detector.go        # Detector interface
+    port/replacer.go        # Replacer interface
+    port/pipeline.go        # Result type
+  internal/
+    engine/engine.go        # Orchestrator: runs detectors, merges, deduplicates
+  adapter/
+    detector/
+      common/               # Global patterns (email, credit card, IBAN, IP, URL, MAC)
+      us/                   # US-specific (SSN, EIN, ITIN, phone, passport, ZIP, Medicare)
+      nl/                   # Netherlands (BSN, phone, postal, KvK, ID documents)
+      eu/                   # EU-wide (VAT, passport MRZ)
+      gb/                   # UK (NIN, NHS, UTR, phone, postcode)
+      de/                   # Germany (Steuer-ID, ID card, Sozialversicherung, phone, PLZ)
+      fr/                   # France (NIR, NIF, ID card, phone, postal code)
+    replacer/
+      redact.go             # [TYPE] placeholders
+      mask.go               # Character masking with preserved suffix
+      hash.go               # Deterministic SHA-256 hashing
+      custom.go             # User-defined replacement function
+```
+
+## Processing Pipeline
+
+1. **Configuration** -- The caller creates a `Wuming` instance with options (locale, replacer, thresholds, concurrency).
+2. **Detector selection** -- The engine filters detectors based on configured locales. Global detectors (those returning no locales) always run.
+3. **Concurrent detection** -- Selected detectors run in parallel, bounded by the concurrency setting.
+4. **Merge and dedup** -- All matches are collected, sorted by position, and overlapping matches are resolved by preferring higher confidence.
+5. **Filtering** -- Matches below the confidence threshold or outside the requested PII types are removed.
+6. **Replacement** -- The replacer substitutes matched text spans in reverse order (to preserve byte offsets) and returns the redacted text alongside all match metadata.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See [CHANGELOG.md](https://github.com/taoq-ai/wuming/blob/main/CHANGELOG.md) for the full changelog.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,117 @@
+# Contributing
+
+Thank you for your interest in contributing to wuming. This guide covers the development workflow, how to add new detectors, and code conventions.
+
+## Development Setup
+
+1. **Clone the repository:**
+
+    ```bash
+    git clone https://github.com/taoq-ai/wuming.git
+    cd wuming
+    ```
+
+2. **Verify Go version:**
+
+    ```bash
+    go version
+    # Requires Go 1.22+
+    ```
+
+3. **Run the tests:**
+
+    ```bash
+    make test
+    ```
+
+4. **Run the linter:**
+
+    ```bash
+    make lint
+    ```
+
+## How to Add a New Detector
+
+### 1. Create the package
+
+Create a new directory under `adapter/detector/<locale>/` for locale-specific detectors, or add to `adapter/detector/common/` for global patterns.
+
+### 2. Implement the Detector interface
+
+```go
+package xx
+
+import (
+    "context"
+    "regexp"
+
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "xx"
+
+var myPatternRe = regexp.MustCompile(`...`)
+
+type MyDetector struct{}
+
+func NewMyDetector() *MyDetector { return &MyDetector{} }
+
+func (d *MyDetector) Name() string              { return "xx/my_pattern" }
+func (d *MyDetector) Locales() []string         { return []string{locale} }
+func (d *MyDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *MyDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+    // Your detection logic here
+    return nil, nil
+}
+```
+
+### 3. Add a helpers.go file
+
+If your locale package needs shared utilities (like a `findAll` helper), add a `helpers.go` file following the convention used by existing locale packages.
+
+### 4. Write tests
+
+Create a `xx_test.go` file with table-driven tests covering:
+
+- Valid matches (true positives)
+- Invalid matches (true negatives)
+- Edge cases (boundary values, formatting variations)
+- Checksum validation (if applicable)
+
+### 5. Register the detector
+
+Add your detector to the appropriate registry so that it is included when users configure that locale.
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Use table-driven tests
+- Keep detectors focused -- one PII type per detector
+- Include doc comments on all exported types and functions
+- Name detector files after the PII type they detect (e.g., `bsn.go`, `ssn.go`, `phone.go`)
+- Set confidence scores consistent with existing detectors:
+    - 0.90+ for checksum-validated patterns
+    - 0.80-0.89 for structurally validated patterns
+    - 0.60-0.79 for regex-only or context-dependent patterns
+
+## Testing
+
+All tests should pass before submitting a pull request:
+
+```bash
+make test
+```
+
+Run tests for a specific package:
+
+```bash
+go test ./adapter/detector/xx/...
+```
+
+## Pull Requests
+
+- Create a feature branch from `main`
+- Write a clear PR description
+- Ensure all tests pass
+- Reference any related issues

--- a/docs/detectors/common.md
+++ b/docs/detectors/common.md
@@ -1,0 +1,97 @@
+# Common (Global) Detectors
+
+Common detectors are locale-independent and run regardless of which locale is configured. They cover PII patterns that are universal across geographies.
+
+## Email Address
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/email` |
+| PII Type | `EMAIL` |
+| Confidence | 0.95 |
+| Validation | Regex pattern matching |
+
+Detects email addresses in standard `user@domain.tld` format.
+
+**Examples:** `john@example.com`, `user.name+tag@company.co.uk`
+
+---
+
+## Credit Card
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/creditcard` |
+| PII Type | `CREDIT_CARD` |
+| Confidence | 0.95 |
+| Validation | Luhn algorithm |
+
+Detects credit card numbers (13-19 digits) with optional separators (spaces or hyphens). Every candidate is validated using the **Luhn checksum algorithm** to eliminate false positives.
+
+**Examples:** `4111 1111 1111 1111`, `5500-0000-0000-0004`
+
+!!! info "Regulatory Context"
+    Credit card numbers are regulated under **PCI-DSS** (Payment Card Industry Data Security Standard) globally. Severity: **Critical**.
+
+---
+
+## IBAN
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/iban` |
+| PII Type | `IBAN` |
+| Confidence | 0.95 |
+| Validation | ISO 13616 mod-97 checksum |
+
+Detects International Bank Account Numbers. The format is a 2-letter country code, 2 check digits, and up to 30 alphanumeric characters. Every candidate is validated using the **mod-97 algorithm** (ISO 13616).
+
+**Examples:** `NL91ABNA0417164300`, `DE89370400440532013000`
+
+---
+
+## IP Address
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/ip` |
+| PII Type | `IP_ADDRESS` |
+| Confidence | 0.90 |
+| Validation | IPv4 octet range (0-255), IPv6 regex |
+
+Detects both IPv4 and IPv6 addresses. IPv4 addresses are validated to ensure each octet is within the 0-255 range.
+
+**Examples:** `192.168.1.1`, `2001:0db8:85a3:0000:0000:8a2e:0370:7334`
+
+!!! info "Regulatory Context"
+    IP addresses are considered personal data under **GDPR** (EU) when they can be linked to an individual.
+
+---
+
+## URL
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/url` |
+| PII Type | `URL` |
+| Confidence | 0.90 |
+| Validation | Regex pattern matching |
+
+Detects URLs with `http://` or `https://` schemes.
+
+**Examples:** `https://example.com/profile/12345`, `http://intranet.company.com/users/jdoe`
+
+---
+
+## MAC Address
+
+| Property | Value |
+|----------|-------|
+| Detector | `common/mac` |
+| PII Type | `MAC_ADDRESS` |
+| Confidence | 0.90 |
+| Validation | Regex pattern matching |
+
+Detects MAC addresses in colon-separated, hyphen-separated, and dot-separated formats.
+
+**Examples:** `00:1A:2B:3C:4D:5E`, `00-1A-2B-3C-4D-5E`, `001A.2B3C.4D5E`

--- a/docs/detectors/de.md
+++ b/docs/detectors/de.md
@@ -1,0 +1,91 @@
+# Germany Detectors
+
+German detectors cover PII patterns specific to Germany. They are activated when the `"de"` locale is configured.
+
+## Steuerliche Identifikationsnummer (Steuer-ID)
+
+| Property | Value |
+|----------|-------|
+| Detector | `de/steuer_id` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Digit distribution + ISO 7064 Mod 11,10 check digit |
+
+Detects German tax identification numbers (11 digits). Validation is two-fold:
+
+1. **Digit distribution check** (first 10 digits): exactly one digit must appear twice, exactly one digit must not appear at all, and the remaining 8 digits each appear exactly once. The first digit cannot be 0.
+2. **Check digit** (11th digit): validated using the **ISO 7064 Mod 11,10** algorithm.
+
+**Examples:** `12345679812` (valid structure with correct check digit)
+
+!!! warning "Regulatory Context"
+    The Steuer-ID is regulated under the **Abgabenordnung (AO)** and is a lifelong identifier. Protected under **GDPR** and **BDSG** (Bundesdatenschutzgesetz). Severity: **High**.
+
+---
+
+## Personalausweisnummer (ID Card)
+
+| Property | Value |
+|----------|-------|
+| Detector | `de/id_card` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.75 |
+| Validation | Weighted checksum (7, 3, 1 cycling) |
+
+Detects German national ID card numbers (10 alphanumeric characters). The first character is a letter from the set {L, M, N, P, R, T, V, W, X, Y}, followed by 8 alphanumeric characters and 1 check digit. The check digit is validated using a **weighted checksum** with cycling weights 7, 3, 1.
+
+**Examples:** `L01X00T471`
+
+---
+
+## Sozialversicherungsnummer (Social Security Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `de/sozialversicherung` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.75 |
+| Validation | Date component validation |
+
+Detects German social security numbers (12 characters: `AADDMMYYXNNN` -- area number, birth date, birth name initial, serial + check). Validates that the date components (day 01-31, month 01-12) and area number (non-zero) are within valid ranges.
+
+**Examples:** `12 010290 A 123`, `12010290A123`
+
+!!! info "Regulatory Context"
+    The Sozialversicherungsnummer is issued by the **Deutsche Rentenversicherung** and is protected under **SGB IV** (Sozialgesetzbuch). Severity: **High**.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `de/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | German phone format |
+
+Detects German phone numbers in international and domestic formats:
+
+- **International:** `+49 XXX XXXXXXX`, `0049 XXX XXXXXXX`
+- **Mobile:** `01XX XXXXXXXX` (e.g., 0151, 0160, 0170, etc.)
+- **Landline:** `0XXX XXXXXXX`
+
+Supports separators: space, dash, dot, slash.
+
+**Examples:** `+49 30 12345678`, `0151-12345678`, `030/1234567`
+
+---
+
+## Postleitzahl (PLZ)
+
+| Property | Value |
+|----------|-------|
+| Detector | `de/plz` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 (bare) / 0.80-0.85 (with context) |
+| Validation | Range check + context boost |
+
+Detects German postal codes (5 digits, range 01001-99998). Because 5-digit sequences are common, the detector uses **context boosting** -- confidence is increased when keywords like "PLZ", "Postleitzahl", "Str.", "Stadt", "Ort", "Adresse", or "Anschrift" appear in the surrounding text.
+
+**Examples:** `PLZ 10115`, `Adresse: Berliner Str. 1, 10115 Berlin`

--- a/docs/detectors/eu.md
+++ b/docs/detectors/eu.md
@@ -1,0 +1,69 @@
+# EU-wide Detectors
+
+EU-wide detectors cover PII patterns that apply across European Union member states. They are activated when the `"eu"` locale is configured.
+
+## VAT Identification Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `eu/vat` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.90 |
+| Validation | Country prefix + format regex |
+
+Detects EU VAT identification numbers for all 27 member states. Each number begins with a two-letter country prefix followed by a country-specific format.
+
+**Supported countries and formats:**
+
+| Prefix | Country | Format |
+|--------|---------|--------|
+| AT | Austria | `ATU` + 8 digits |
+| BE | Belgium | `BE0` or `BE1` + 9 digits |
+| BG | Bulgaria | 9-10 digits |
+| CY | Cyprus | 8 digits + 1 letter |
+| CZ | Czech Republic | 8-10 digits |
+| DE | Germany | 9 digits |
+| DK | Denmark | 8 digits |
+| EE | Estonia | 9 digits |
+| EL | Greece | 9 digits |
+| ES | Spain | 1 alphanumeric + 7 digits + 1 alphanumeric |
+| FI | Finland | 8 digits |
+| FR | France | 2 alphanumeric + 9 digits |
+| HR | Croatia | 11 digits |
+| HU | Hungary | 8 digits |
+| IE | Ireland | 1 digit + 1 alphanumeric + 5 digits + 1-2 letters |
+| IT | Italy | 11 digits |
+| LT | Lithuania | 9 or 12 digits |
+| LU | Luxembourg | 8 digits |
+| LV | Latvia | 11 digits |
+| MT | Malta | 8 digits |
+| NL | Netherlands | 9 digits + `B` + 2 digits |
+| PL | Poland | 10 digits |
+| PT | Portugal | 9 digits |
+| RO | Romania | 2-10 digits |
+| SE | Sweden | 12 digits |
+| SI | Slovenia | 8 digits |
+| SK | Slovakia | 10 digits |
+
+**Examples:** `NL123456789B01`, `DE123456789`, `ATU12345678`
+
+!!! info "Regulatory Context"
+    VAT numbers are business identifiers regulated under EU VAT Directive (2006/112/EC). While they are primarily organizational, they can identify sole traders and are therefore considered PII under the GDPR.
+
+---
+
+## Passport MRZ (Machine Readable Zone)
+
+| Property | Value |
+|----------|-------|
+| Detector | `eu/passport_mrz` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.95 |
+| Validation | ICAO 9303 TD3 format |
+
+Detects ICAO 9303 TD3 (passport) Machine Readable Zones. The MRZ consists of two lines of 44 characters each, containing the document type, issuing state, holder's name, passport number, nationality, date of birth, sex, expiry date, and check digits.
+
+This detector has a high confidence score because the MRZ format is highly structured and unlikely to produce false positives.
+
+!!! warning "Regulatory Context"
+    Passport MRZ data contains multiple PII elements (name, nationality, date of birth, passport number) and is protected under GDPR and national identity document laws. Severity: **Critical**.

--- a/docs/detectors/fr.md
+++ b/docs/detectors/fr.md
@@ -1,0 +1,100 @@
+# France Detectors
+
+French detectors cover PII patterns specific to France. They are activated when the `"fr"` locale is configured.
+
+## NIR (Social Security Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `fr/nir` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Mod-97 control key |
+
+Detects the French NIR (Numero d'Inscription au Repertoire), also known as the numero de securite sociale. The NIR is a 15-digit number with the structure `X XX XX XXXXX XXX XX`:
+
+- Digit 1: sex (1=male, 2=female)
+- Digits 2-3: year of birth
+- Digits 4-5: month of birth (01-12)
+- Digits 6-7: department (01-95, or 2A/2B for Corsica)
+- Digits 8-10: commune code
+- Digits 11-13: order number
+- Digits 14-15: control key
+
+The control key is validated as `97 - (first 13 digits mod 97)`. Special handling is applied for Corsica departments (2A and 2B) which contain letters in the department field.
+
+**Examples:** `1 85 05 78 006 084 36` (with spaces), `185057800608436` (without spaces)
+
+!!! warning "Regulatory Context"
+    The NIR is regulated under French law and the **CNIL** (Commission nationale de l'informatique et des libertes). Its use is strictly controlled and protected under **GDPR**. Severity: **High**.
+
+---
+
+## NIF (Tax Identification Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `fr/nif` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.70 |
+| Validation | Regex pattern |
+
+Detects the French Numero d'Identification Fiscale (13 digits, first digit 0-3). Supports formatted versions with spaces, dashes, or dots as separators.
+
+**Examples:** `01 23 456 789 012`, `0123456789012`
+
+---
+
+## CNI (National Identity Card)
+
+| Property | Value |
+|----------|-------|
+| Detector | `fr/id_card` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.65 |
+| Validation | Regex pattern (old + new format) |
+
+Detects French Carte Nationale d'Identite numbers in both formats:
+
+- **Old format** (before 2021): 12 digits
+- **New format** (since 2021): 9 alphanumeric characters
+
+**Examples:** `123456789012` (old), `ABC123DEF` (new)
+
+!!! note
+    This detector has a lower confidence score because both formats can match non-CNI strings. Use `WithConfidenceThreshold()` to filter as needed.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `fr/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | French phone format |
+
+Detects French phone numbers in local and international formats:
+
+- **Local:** `0X XX XX XX XX` (where X = 1-7 for landline/mobile)
+- **International:** `+33 X XX XX XX XX`
+
+Supports separators: space, dot, dash.
+
+**Examples:** `01 23 45 67 89`, `+33 6 12 34 56 78`, `06.12.34.56.78`
+
+---
+
+## Postal Code (Code Postal)
+
+| Property | Value |
+|----------|-------|
+| Detector | `fr/postal` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Department prefix validation |
+
+Detects French postal codes (5 digits). The first two digits represent the department number and are validated to be within valid ranges (01-95, 97, 98 -- department 96 does not exist).
+
+**Examples:** `75001` (Paris), `13001` (Marseille), `97100` (overseas territory)

--- a/docs/detectors/gb.md
+++ b/docs/detectors/gb.md
@@ -1,0 +1,92 @@
+# United Kingdom Detectors
+
+UK detectors cover PII patterns specific to the United Kingdom. They are activated when the `"gb"` locale is configured.
+
+## National Insurance Number (NIN)
+
+| Property | Value |
+|----------|-------|
+| Detector | `gb/nin` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.85 |
+| Validation | HMRC prefix rules |
+
+Detects UK National Insurance Numbers in the format `XX 99 99 99 X` (2 letters, 6 digits, 1 letter A-D). Validates the two-letter prefix against HMRC allocation rules:
+
+- First letter must not be D, F, I, Q, U, or V
+- Second letter must not be D, F, I, O, Q, U, or V
+- Certain prefix combinations are never allocated: BG, GB, NK, KN, TN, NT, ZZ
+
+**Examples:** `AB 12 34 56 C`, `AB123456C`
+
+!!! warning "Regulatory Context"
+    NINs are regulated by **HMRC** and protected under the **UK Data Protection Act 2018** (UK GDPR). Severity: **High**.
+
+---
+
+## NHS Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `gb/nhs` |
+| PII Type | `HEALTH_ID` |
+| Confidence | 0.90 |
+| Validation | Mod-11 check digit |
+
+Detects UK NHS Numbers (10 digits, optionally formatted as `XXX XXX XXXX` or `XXX-XXX-XXXX`). Validates using the **mod-11 algorithm**: the first 9 digits are weighted (10, 9, 8, ..., 2), summed, and the check digit is `11 - (sum % 11)`. If the remainder is 10, the number is invalid; if 11, the check digit is 0.
+
+**Examples:** `943 476 5919`, `943-476-5919`, `9434765919`
+
+!!! warning "Regulatory Context"
+    NHS Numbers are protected under the **NHS Act 2006** and **UK GDPR**. They are classified as health data and subject to special category processing rules. Severity: **High**.
+
+---
+
+## Unique Taxpayer Reference (UTR)
+
+| Property | Value |
+|----------|-------|
+| Detector | `gb/utr` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.55 (bare) / 0.85 (with context) |
+| Validation | Context-boosted confidence |
+
+Detects UK Unique Taxpayer References (10-digit numbers). Because bare 10-digit sequences are highly ambiguous, the detector uses context boosting -- confidence is raised to 0.85 when preceded by keywords like "UTR", "tax reference", or "unique taxpayer reference".
+
+**Examples:** `UTR: 1234567890`, `Tax reference: 1234567890`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `gb/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | UK phone format |
+
+Detects UK phone numbers in mobile and landline formats:
+
+- **Mobile:** `07XXX XXXXXX`, `+44 7XXX XXXXXX`
+- **London:** `020 XXXX XXXX`, `+44 20 XXXX XXXX`
+- **Landline:** `01XX XXX XXXX`, `+44 1XX XXX XXXX`
+
+Supports space, dash, and dot separators.
+
+**Examples:** `07911 123456`, `+44 20 7946 0958`, `01onal234-567-8901`
+
+---
+
+## Postcode
+
+| Property | Value |
+|----------|-------|
+| Detector | `gb/postcode` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.90 |
+| Validation | UK postcode format regex |
+
+Detects UK postcodes in all valid formats: `A9 9AA`, `A99 9AA`, `A9A 9AA`, `AA9 9AA`, `AA99 9AA`, `AA9A 9AA`.
+
+**Examples:** `SW1A 1AA`, `EC1A 1BB`, `W1D 3QU`

--- a/docs/detectors/nl.md
+++ b/docs/detectors/nl.md
@@ -1,0 +1,92 @@
+# Netherlands Detectors
+
+Netherlands detectors cover PII patterns specific to the Dutch context. They are activated when the `"nl"` locale is configured.
+
+## Burgerservicenummer (BSN)
+
+| Property | Value |
+|----------|-------|
+| Detector | `nl/bsn` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | 11-proof checksum |
+
+Detects Dutch citizen service numbers (BSN). The BSN is a 9-digit number validated using the **11-proof** (elfproef) algorithm:
+
+`9*d1 + 8*d2 + 7*d3 + 6*d4 + 5*d5 + 4*d6 + 3*d7 + 2*d8 - 1*d9`
+
+The result must be divisible by 11 and must not be 0.
+
+**Examples:** `123456782`, `123.456.782`, `123 456 782`
+
+!!! warning "Regulatory Context"
+    The BSN is regulated under **Wet algemene bepalingen burgerservicenummer (Wabb)**. Its use is restricted to government agencies, healthcare providers, and certain other authorized organizations. Severity: **High**.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `nl/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Dutch phone format |
+
+Detects Dutch phone numbers in mobile and landline formats:
+
+- **Mobile:** `06-XXXXXXXX`, `+31 6 XXXXXXXX`, `0031 6 XXXXXXXX`
+- **Landline:** `0XX-XXXXXXX`, `+31 XX XXXXXXX`
+
+**Examples:** `06-12345678`, `+31 20 1234567`, `0031 6 12345678`
+
+---
+
+## Postal Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `nl/postal` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.90 |
+| Validation | Format + invalid letter combinations |
+
+Detects Dutch postal codes in the `NNNN XX` format (4 digits + 2 uppercase letters). The first digit cannot be 0, and certain letter combinations (`SA`, `SD`, `SS`) that are not used in the Dutch postal system are excluded.
+
+**Examples:** `1234 AB`, `1012WX`
+
+---
+
+## KvK Number (Chamber of Commerce)
+
+| Property | Value |
+|----------|-------|
+| Detector | `nl/kvk` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.60 (bare) / 0.90 (with context) |
+| Validation | Context-boosted confidence |
+
+Detects Kamer van Koophandel (Chamber of Commerce) registration numbers. These are 8-digit numbers. Because bare 8-digit sequences are ambiguous, confidence is boosted to 0.90 when preceded by keywords like "KvK" or "Kamer van Koophandel".
+
+**Examples:** `KvK: 12345678`, `Kamer van Koophandel: 87654321`
+
+---
+
+## ID Document (ID Card & Passport)
+
+| Property | Value |
+|----------|-------|
+| Detector | `nl/id_document` |
+| PII Type | `NATIONAL_ID` / `PASSPORT` |
+| Confidence | 0.70 |
+| Validation | Pattern matching |
+
+Detects Dutch identity card and passport numbers:
+
+- **ID Card:** 9-character alphanumeric string containing both letters and digits (e.g., `SPECI2014`)
+- **Passport:** 2 uppercase letters followed by 7 alphanumeric characters containing at least one digit
+
+**Examples:** `SPECI2014`, `NW12P4F07`
+
+!!! info "Regulatory Context"
+    Identity document numbers are protected under the **GDPR** and Dutch implementation laws (UAVG). Severity: **High**.

--- a/docs/detectors/overview.md
+++ b/docs/detectors/overview.md
@@ -1,0 +1,74 @@
+# Detectors Overview
+
+Detectors are the core building blocks of wuming. Each detector scans input text for a specific type of PII and returns a list of matches with position, confidence, and metadata.
+
+## Supported Locales and Patterns
+
+| Locale | Detector | PII Type | Confidence | Validation |
+|--------|----------|----------|------------|------------|
+| Global | Email | EMAIL | 0.95 | Regex |
+| Global | Credit Card | CREDIT_CARD | 0.95 | Luhn algorithm |
+| Global | IBAN | IBAN | 0.95 | ISO 13616 mod-97 |
+| Global | IP Address | IP_ADDRESS | 0.90 | IPv4 octet range, IPv6 regex |
+| Global | URL | URL | 0.90 | Regex |
+| Global | MAC Address | MAC_ADDRESS | 0.90 | Regex |
+| US | SSN | NATIONAL_ID | 0.85 | Area/group/serial rules |
+| US | EIN | TAX_ID | 0.85 | IRS prefix validation |
+| US | ITIN | TAX_ID | 0.80 | Group range validation |
+| US | Phone | PHONE | 0.80 | NANP format |
+| US | Passport | PASSPORT | 0.60 | Regex |
+| US | ZIP Code | POSTAL_CODE | 0.60 | Regex (5 or 5+4) |
+| US | Medicare | HEALTH_ID | 0.80 | MBI pattern |
+| NL | BSN | NATIONAL_ID | 0.90 | 11-proof checksum |
+| NL | Phone | PHONE | 0.85 | Dutch format |
+| NL | Postal Code | POSTAL_CODE | 0.90 | Format + invalid combos |
+| NL | KvK | TAX_ID | 0.60-0.90 | Context-boosted |
+| NL | ID Document | NATIONAL_ID / PASSPORT | 0.70 | Pattern matching |
+| EU | VAT Number | TAX_ID | 0.90 | Country prefix regex |
+| EU | Passport MRZ | PASSPORT | 0.95 | ICAO 9303 TD3 format |
+| GB | NIN | NATIONAL_ID | 0.85 | HMRC prefix rules |
+| GB | NHS Number | HEALTH_ID | 0.90 | Mod-11 check digit |
+| GB | UTR | TAX_ID | 0.55-0.85 | Context-boosted |
+| GB | Phone | PHONE | 0.85 | UK format |
+| GB | Postcode | POSTAL_CODE | 0.90 | UK format regex |
+| DE | Steuer-ID | TAX_ID | 0.85 | ISO 7064 Mod 11,10 |
+| DE | ID Card | NATIONAL_ID | 0.75 | Weighted checksum (7,3,1) |
+| DE | Sozialversicherung | NATIONAL_ID | 0.75 | Date validation |
+| DE | Phone | PHONE | 0.85 | German format |
+| DE | PLZ | POSTAL_CODE | 0.60-0.85 | Range + context boost |
+| FR | NIR | NATIONAL_ID | 0.90 | Mod-97 control key |
+| FR | NIF | TAX_ID | 0.70 | Regex |
+| FR | ID Card | NATIONAL_ID | 0.65 | Old (12-digit) + new (9-char) |
+| FR | Phone | PHONE | 0.85 | French format |
+| FR | Postal Code | POSTAL_CODE | 0.60 | Department prefix validation |
+
+## The Detector Interface
+
+Every detector implements the `port.Detector` interface:
+
+```go
+type Detector interface {
+    Detect(ctx context.Context, text string) ([]model.Match, error)
+    Name() string
+    Locales() []string
+    PIITypes() []model.PIIType
+}
+```
+
+- **`Detect`** -- Scans the input text and returns all matches found.
+- **`Name`** -- Returns a unique identifier (e.g., `"nl/bsn"`, `"common/email"`).
+- **`Locales`** -- Returns which locales this detector supports. An empty slice means the detector is locale-independent (global).
+- **`PIITypes`** -- Returns which PII types this detector can find.
+
+## Confidence Scoring
+
+Each match carries a confidence score between 0.0 and 1.0:
+
+- **0.90 -- 0.95**: High confidence, validated by checksum or strong structural rules (e.g., credit card with Luhn, IBAN with mod-97, BSN with 11-proof)
+- **0.80 -- 0.89**: Good confidence, structural validation but no checksum (e.g., SSN area rules, phone formats)
+- **0.60 -- 0.79**: Moderate confidence, pattern-based with limited validation (e.g., ZIP codes, passport numbers, bare KvK numbers)
+- **Below 0.60**: Low confidence, context-dependent patterns
+
+Some detectors use **context boosting** -- if keywords like "BSN", "KvK", "PLZ", or "UTR" appear near a candidate match, the confidence is increased. This reduces false positives for ambiguous patterns like bare digit sequences.
+
+Use `WithConfidenceThreshold()` to filter out matches below a desired confidence level.

--- a/docs/detectors/us.md
+++ b/docs/detectors/us.md
@@ -1,0 +1,121 @@
+# United States Detectors
+
+US detectors cover PII patterns specific to the United States. They are activated when the `"us"` locale is configured.
+
+## Social Security Number (SSN)
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/ssn` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.85 |
+| Validation | Area/group/serial rules |
+
+Detects US Social Security Numbers in the `XXX-XX-XXXX` format (with or without dashes).
+
+**Validation rules:**
+
+- Area number (first 3 digits) cannot be `000`, `666`, or `900-999`
+- Group number (middle 2 digits) cannot be `00`
+- Serial number (last 4 digits) cannot be `0000`
+
+**Examples:** `123-45-6789`, `123456789`
+
+!!! warning "Regulatory Context"
+    SSNs are protected under various US federal and state privacy laws. Severity: **High**.
+
+---
+
+## Employer Identification Number (EIN)
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/ein` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | IRS campus prefix validation |
+
+Detects US EINs in the `XX-XXXXXXX` format. The two-digit prefix is validated against the IRS campus assignment table.
+
+**Examples:** `12-3456789`, `95-1234567`
+
+---
+
+## Individual Taxpayer Identification Number (ITIN)
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/itin` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.80 |
+| Validation | Group range validation |
+
+Detects US ITINs (assigned to individuals who are not eligible for an SSN). Starts with `9`, followed by a group number in valid ITIN ranges (50-65, 70-88, 90-92, 94-99).
+
+**Examples:** `9XX-70-XXXX`, `912-78-1234`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.80 |
+| Validation | NANP format |
+
+Detects US phone numbers in NANP (North American Numbering Plan) format. Supports optional `+1` prefix, parenthesized area codes, and various separators (space, dash, dot).
+
+**Examples:** `(555) 123-4567`, `+1 555.123.4567`, `5551234567`
+
+---
+
+## Passport Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex pattern |
+
+Detects US passport numbers (8-9 digits, optionally prefixed with a letter for newer formats).
+
+**Examples:** `123456789`, `A12345678`
+
+!!! note
+    This detector has a lower confidence score because bare digit sequences can produce false positives. Use `WithConfidenceThreshold()` to filter as needed.
+
+---
+
+## ZIP Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/zip` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex pattern |
+
+Detects US ZIP codes in 5-digit format, optionally with the ZIP+4 extension.
+
+**Examples:** `90210`, `10001-1234`
+
+---
+
+## Medicare Beneficiary Identifier (MBI)
+
+| Property | Value |
+|----------|-------|
+| Detector | `us/medicare` |
+| PII Type | `HEALTH_ID` |
+| Confidence | 0.80 |
+| Validation | MBI character pattern |
+
+Detects US Medicare Beneficiary Identifiers. The 11-character MBI follows a strict character pattern: `C A AN N AA N AN AN` where C=1-9, A=letter (excluding S,L,O,I,B,Z), N=digit, AN=alphanumeric (with same letter exclusions).
+
+**Examples:** `1EG4-TE5-MK72` (without formatting: `1EG4TE5MK72`)
+
+!!! warning "Regulatory Context"
+    MBIs are protected under **HIPAA** (Health Insurance Portability and Accountability Act). Severity: **High**.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,48 @@
+# Installation
+
+## Requirements
+
+- **Go 1.22** or later
+- No external dependencies beyond the Go standard library
+
+## Install
+
+Add wuming to your Go module:
+
+```bash
+go get github.com/taoq-ai/wuming
+```
+
+## Verify
+
+Create a simple test file to verify the installation:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/taoq-ai/wuming"
+)
+
+func main() {
+    w := wuming.New()
+    result, err := w.Process(context.Background(), "Email: test@example.com")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Redacted)
+    // Output: Email: [EMAIL]
+}
+```
+
+Run it:
+
+```bash
+go run main.go
+```
+
+If you see the redacted output, wuming is installed and working correctly.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,157 @@
+# Quick Start
+
+This guide walks through the most common usage patterns for wuming.
+
+## Basic Usage
+
+The simplest way to use wuming is with the default configuration, which loads all available detectors and uses the redact replacer:
+
+```go
+w := wuming.New()
+result, err := w.Process(ctx, "My SSN is 123-45-6789")
+// result.Redacted: "My SSN is [NATIONAL_ID]"
+```
+
+## Configuring Locales
+
+To restrict detection to a specific locale (global detectors always run regardless):
+
+```go
+w := wuming.New(
+    wuming.WithLocale("nl"),
+)
+result, err := w.Process(ctx, "BSN: 123456782, SSN: 123-45-6789")
+// Only the BSN is detected (SSN is US-specific and filtered out)
+```
+
+You can combine multiple locales:
+
+```go
+w := wuming.New(
+    wuming.WithLocale("nl"),
+    wuming.WithLocale("de"),
+)
+```
+
+## Choosing a Replacer Strategy
+
+wuming ships with four replacer strategies:
+
+=== "Redact"
+
+    Replaces PII with a type label (default):
+
+    ```go
+    import "github.com/taoq-ai/wuming/adapter/replacer"
+
+    w := wuming.New(
+        wuming.WithReplacer(replacer.NewRedact()),
+    )
+    // "john@example.com" -> "[EMAIL]"
+    ```
+
+=== "Mask"
+
+    Replaces characters with asterisks, preserving the last 4:
+
+    ```go
+    w := wuming.New(
+        wuming.WithReplacer(replacer.NewMask()),
+    )
+    // "john@example.com" -> "************.com"
+    ```
+
+=== "Hash"
+
+    Replaces PII with a deterministic SHA-256 hash (truncated to 16 hex chars):
+
+    ```go
+    w := wuming.New(
+        wuming.WithReplacer(replacer.NewHash()),
+    )
+    // "john@example.com" -> "a8cfcd74832004e0"
+    ```
+
+=== "Custom"
+
+    Provide your own replacement function:
+
+    ```go
+    w := wuming.New(
+        wuming.WithReplacer(replacer.NewCustom("my-replacer", func(m model.Match) string {
+            return fmt.Sprintf("<%s:REDACTED>", m.Type)
+        })),
+    )
+    ```
+
+## Filtering by PII Type
+
+Restrict detection to specific PII types:
+
+```go
+w := wuming.New(
+    wuming.WithPIITypes(model.Email, model.Phone),
+)
+```
+
+## Confidence Threshold
+
+Filter out low-confidence matches:
+
+```go
+w := wuming.New(
+    wuming.WithConfidenceThreshold(0.8),
+)
+```
+
+## Concurrency Control
+
+Limit the number of detectors running in parallel:
+
+```go
+w := wuming.New(
+    wuming.WithConcurrency(4),
+)
+```
+
+## Full Working Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/taoq-ai/wuming"
+    "github.com/taoq-ai/wuming/adapter/replacer"
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+func main() {
+    w := wuming.New(
+        wuming.WithLocale("nl"),
+        wuming.WithReplacer(replacer.NewMask()),
+        wuming.WithConfidenceThreshold(0.7),
+        wuming.WithPIITypes(model.Email, model.Phone, model.NationalID),
+        wuming.WithConcurrency(4),
+    )
+
+    text := "Contact Jan at jan@bedrijf.nl or 06-12345678. BSN: 123456782."
+
+    result, err := w.Process(context.Background(), text)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Original:", result.Original)
+    fmt.Println("Redacted:", result.Redacted)
+    fmt.Printf("Matches:  %d\n", result.MatchCount)
+
+    for _, m := range result.Matches {
+        fmt.Printf("  - %s: %q (confidence: %.2f, detector: %s)\n",
+            m.Type, m.Value, m.Confidence, m.Detector)
+    }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+# 无名 wuming
+
+> *The Tao that can be told is not the eternal Tao.*
+> *The name that can be named is not the eternal name.*
+> *The nameless is the beginning of heaven and earth.*
+>
+> -- Tao Te Ching, Chapter 1
+
+---
+
+**wuming** (无名 -- "The Nameless") is a Go library for detecting and removing Personally Identifiable Information (PII) from text. It supports global PII standards across multiple locales and provides pluggable detection and replacement strategies via a hexagonal architecture.
+
+## Key Features
+
+- **Multi-locale detection** -- built-in support for common (global), US, NL, EU, GB, DE, and FR PII patterns
+- **Pluggable replacers** -- redact, mask, hash, or bring your own replacement strategy
+- **Hexagonal architecture** -- clean separation between domain logic and adapters for easy extension
+- **Concurrent processing** -- detectors run in parallel with configurable concurrency limits
+- **Confidence scoring** -- each match carries a confidence score for fine-grained filtering
+- **Checksum validation** -- Luhn, mod-97, 11-proof, mod-11, and other algorithms reduce false positives
+
+## Quick Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/taoq-ai/wuming"
+)
+
+func main() {
+    w := wuming.New(
+        wuming.WithLocale("nl"),
+    )
+
+    result, err := w.Process(context.Background(),
+        "Call me at 06-12345678 or email john@example.com",
+    )
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(result.Redacted)
+    // Output: Call me at [PHONE] or email [EMAIL]
+}
+```
+
+## Getting Started
+
+Head over to the [Installation](getting-started/installation.md) guide to add wuming to your project, then follow the [Quick Start](getting-started/quickstart.md) to begin detecting PII in minutes.

--- a/docs/replacers.md
+++ b/docs/replacers.md
@@ -1,0 +1,124 @@
+# Replacers
+
+Replacers determine how detected PII is substituted in the output text. wuming ships with four built-in strategies, and you can create your own.
+
+## Built-in Replacers
+
+### Redact
+
+Replaces each match with a type-labeled placeholder. This is the **default** replacer.
+
+```go
+import "github.com/taoq-ai/wuming/adapter/replacer"
+
+r := replacer.NewRedact()
+// "john@example.com" -> "[EMAIL]"
+// "123-45-6789"      -> "[NATIONAL_ID]"
+```
+
+The placeholder format defaults to `[%s]` where `%s` is the PII type string. You can customize it:
+
+```go
+r := &replacer.Redact{Format: "<%s>"}
+// "john@example.com" -> "<EMAIL>"
+```
+
+---
+
+### Mask
+
+Replaces characters with a mask character, preserving the last N characters.
+
+```go
+r := replacer.NewMask()
+// Default: mask with '*', preserve last 4 characters
+// "john@example.com" -> "************.com"
+// "123-45-6789"      -> "*******6789"
+```
+
+Customize the mask character and number of preserved characters:
+
+```go
+r := &replacer.Mask{Char: '#', Preserve: 2}
+// "john@example.com" -> "##############om"
+```
+
+---
+
+### Hash
+
+Replaces each match with a deterministic SHA-256 hash, truncated to a configurable length. The same input always produces the same hash, which is useful for de-identification while preserving the ability to detect duplicates.
+
+```go
+r := replacer.NewHash()
+// Default: 16 hex characters, no salt
+// "john@example.com" -> "a8cfcd74832004e0"
+```
+
+Add a salt for extra security:
+
+```go
+r := &replacer.Hash{Length: 16, Salt: "my-secret-salt"}
+```
+
+---
+
+### Custom
+
+Provide your own replacement function for full control:
+
+```go
+import (
+    "fmt"
+    "github.com/taoq-ai/wuming/adapter/replacer"
+    "github.com/taoq-ai/wuming/domain/model"
+)
+
+r := replacer.NewCustom("my-replacer", func(m model.Match) string {
+    return fmt.Sprintf("[%s:%s:%.0f%%]", m.Locale, m.Type, m.Confidence*100)
+})
+// "123456782" (Dutch BSN) -> "[nl:NATIONAL_ID:90%]"
+```
+
+## Creating a Custom Replacer
+
+You can also implement the `Replacer` interface directly:
+
+```go
+type Replacer interface {
+    Replace(text string, matches []model.Match) (string, error)
+    Name() string
+}
+```
+
+When implementing `Replace`, process matches in **reverse order** (from the end of the text to the beginning) to preserve byte offsets as you substitute text. The built-in replacers demonstrate this pattern -- they sort matches by descending start position before applying replacements.
+
+```go
+type MyReplacer struct{}
+
+func (r *MyReplacer) Name() string { return "my-replacer" }
+
+func (r *MyReplacer) Replace(text string, matches []model.Match) (string, error) {
+    // Sort matches by start position descending
+    sorted := make([]model.Match, len(matches))
+    copy(sorted, matches)
+    sort.Slice(sorted, func(i, j int) bool {
+        return sorted[i].Start > sorted[j].Start
+    })
+
+    result := []byte(text)
+    for _, m := range sorted {
+        replacement := []byte("***")
+        result = append(result[:m.Start], append(replacement, result[m.End:]...)...)
+    }
+    return string(result), nil
+}
+```
+
+Then use it:
+
+```go
+w := wuming.New(
+    wuming.WithReplacer(&MyReplacer{}),
+)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,80 @@
+site_name: wuming (无名)
+site_description: "The Nameless — A Go library for detecting and removing PII from text"
+site_url: https://taoq-ai.github.io/wuming
+repo_url: https://github.com/taoq-ai/wuming
+repo_name: taoq-ai/wuming
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - content.code.copy
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Hexagonal Design: architecture/hexagonal.md
+  - Detectors:
+    - Overview: detectors/overview.md
+    - Common (Global): detectors/common.md
+    - United States: detectors/us.md
+    - Netherlands: detectors/nl.md
+    - EU-wide: detectors/eu.md
+    - United Kingdom: detectors/gb.md
+    - Germany: detectors/de.md
+    - France: detectors/fr.md
+  - Replacers: replacers.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_mermaid
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/taoq-ai/wuming


### PR DESCRIPTION
## Summary
- MkDocs configuration with Material theme (dark/light mode)
- Documentation pages: home, getting started, architecture, detectors (per locale), replacers, contributing
- Mermaid architecture diagrams
- GitHub Actions workflow for automatic deployment to GitHub Pages
- Navigation with tabs and sections

Closes #24

## Test plan
- [ ] `pip install mkdocs-material && mkdocs build` succeeds
- [ ] All pages render correctly
- [ ] Mermaid diagrams display properly
- [ ] GitHub Pages deployment workflow is valid