### PR TITLE
fix: use fence_code_format for Mermaid in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.highlight:


### PR DESCRIPTION
## Summary
- `pymdownx.superfences.fence_mermaid` was removed in newer pymdownx versions
- Replace with `fence_code_format` which is the current approach — Material theme handles Mermaid rendering natively

## Test plan
- [ ] `pip install mkdocs-material && mkdocs build` succeeds
- [ ] Mermaid diagrams render correctly on GitHub Pages