### PR TITLE
feat: add detector registry with zero-config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,26 @@ import (
     "log"
 
     "github.com/taoq-ai/wuming"
-    "github.com/taoq-ai/wuming/adapter/detector/common"
-    "github.com/taoq-ai/wuming/adapter/detector/nl"
 )
 
 func main() {
-    w := wuming.New(
-        wuming.WithDetectors(
-            common.NewEmailDetector(),
-            nl.NewPhoneDetector(),
-        ),
-    )
+    ctx := context.Background()
 
-    result, err := w.Process(context.Background(), "Call me at 06-12345678 or email john@example.com")
+    // Zero config — one line, catches everything.
+    redacted, err := wuming.Redact(ctx, "SSN 123-45-6789, email john@acme.com")
     if err != nil {
         log.Fatal(err)
     }
+    fmt.Println(redacted)
+    // Output: SSN [NATIONAL_ID], email [EMAIL]
 
+    // Locale-specific — only Dutch + common detectors.
+    w := wuming.New(wuming.WithLocale("nl"))
+    result, err := w.Process(ctx, "BSN 123456782, call 06-12345678")
+    if err != nil {
+        log.Fatal(err)
+    }
     fmt.Println(result.Redacted)
-    // Output: Call me at [PHONE] or email [EMAIL]
 }
 ```
 

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -6,29 +6,32 @@ import (
 	"log"
 
 	"github.com/taoq-ai/wuming"
-	"github.com/taoq-ai/wuming/adapter/detector/common"
-	"github.com/taoq-ai/wuming/adapter/detector/nl"
-	"github.com/taoq-ai/wuming/adapter/detector/us"
 )
 
 func main() {
-	// Create a wuming instance with detectors from multiple locales.
+	ctx := context.Background()
+
+	// Zero-config: one line catches all PII across every locale.
+	redacted, err := wuming.Redact(ctx, "Email john@acme.com, SSN 123-45-6789, BSN 111222333, call 06-12345678")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("=== Zero-config Redact ===")
+	fmt.Println("Redacted:", redacted)
+	fmt.Println()
+
+	// Configured instance: restrict to Dutch locale.
 	w := wuming.New(
-		wuming.WithDetectors(
-			common.NewEmailDetector(),
-			common.NewCreditCardDetector(),
-			us.NewSSNDetector(),
-			nl.NewBSNDetector(),
-			nl.NewPhoneDetector(),
-		),
+		wuming.WithLocale("nl"),
 	)
 
 	text := "Email john@acme.com, SSN 123-45-6789, BSN 111222333, call 06-12345678"
-	result, err := w.Process(context.Background(), text)
+	result, err := w.Process(ctx, text)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	fmt.Println("=== Locale-specific (nl) ===")
 	fmt.Println("Original:", result.Original)
 	fmt.Println("Redacted:", result.Redacted)
 	fmt.Printf("Found %d PII matches\n", result.MatchCount)

--- a/adapter/detector/common/all.go
+++ b/adapter/detector/common/all.go
@@ -1,0 +1,15 @@
+package common
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all common (locale-independent) PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewEmailDetector(),
+		NewCreditCardDetector(),
+		NewIPDetector(),
+		NewURLDetector(),
+		NewIBANDetector(),
+		NewMACDetector(),
+	}
+}

--- a/adapter/detector/de/all.go
+++ b/adapter/detector/de/all.go
@@ -1,0 +1,14 @@
+package de
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all German (DE) locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewSteuerIDDetector(),
+		NewSozialversicherungDetector(),
+		NewPhoneDetector(),
+		NewPLZDetector(),
+		NewIDCardDetector(),
+	}
+}

--- a/adapter/detector/eu/all.go
+++ b/adapter/detector/eu/all.go
@@ -1,0 +1,11 @@
+package eu
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all EU locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewPassportMRZDetector(),
+		NewVATDetector(),
+	}
+}

--- a/adapter/detector/fr/all.go
+++ b/adapter/detector/fr/all.go
@@ -1,0 +1,14 @@
+package fr
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all French (FR) locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewNIRDetector(),
+		NewNIFDetector(),
+		NewPhoneDetector(),
+		NewPostalDetector(),
+		NewIDCardDetector(),
+	}
+}

--- a/adapter/detector/gb/all.go
+++ b/adapter/detector/gb/all.go
@@ -1,0 +1,14 @@
+package gb
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all British (GB) locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewNINDetector(),
+		NewNHSDetector(),
+		NewUTRDetector(),
+		NewPhoneDetector(),
+		NewPostcodeDetector(),
+	}
+}

--- a/adapter/detector/nl/all.go
+++ b/adapter/detector/nl/all.go
@@ -1,0 +1,14 @@
+package nl
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all Dutch (NL) locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewBSNDetector(),
+		NewPhoneDetector(),
+		NewPostalDetector(),
+		NewKvKDetector(),
+		NewIDDocumentDetector(),
+	}
+}

--- a/adapter/detector/us/all.go
+++ b/adapter/detector/us/all.go
@@ -1,0 +1,16 @@
+package us
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all US locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewSSNDetector(),
+		NewITINDetector(),
+		NewEINDetector(),
+		NewPhoneDetector(),
+		NewZIPDetector(),
+		NewPassportDetector(),
+		NewMedicareDetector(),
+	}
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -1,0 +1,59 @@
+// Package registry aggregates all PII detectors across locales,
+// providing convenient access to the full set of available detectors.
+package registry
+
+import (
+	"sort"
+
+	"github.com/taoq-ai/wuming/adapter/detector/common"
+	"github.com/taoq-ai/wuming/adapter/detector/de"
+	"github.com/taoq-ai/wuming/adapter/detector/eu"
+	"github.com/taoq-ai/wuming/adapter/detector/fr"
+	"github.com/taoq-ai/wuming/adapter/detector/gb"
+	"github.com/taoq-ai/wuming/adapter/detector/nl"
+	"github.com/taoq-ai/wuming/adapter/detector/us"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+// localeProviders maps locale names to their All() functions.
+var localeProviders = map[string]func() []port.Detector{
+	"common": common.All,
+	"us":     us.All,
+	"nl":     nl.All,
+	"eu":     eu.All,
+	"gb":     gb.All,
+	"de":     de.All,
+	"fr":     fr.All,
+}
+
+// AllDetectors returns every registered PII detector across all locales.
+func AllDetectors() []port.Detector {
+	var all []port.Detector
+	for _, provider := range localeProviders {
+		all = append(all, provider()...)
+	}
+	return all
+}
+
+// DetectorsForLocale returns all detectors for the given locale.
+// Common/global detectors are always included.
+func DetectorsForLocale(locale string) []port.Detector {
+	detectors := common.All()
+	if locale == "common" {
+		return detectors
+	}
+	if provider, ok := localeProviders[locale]; ok {
+		detectors = append(detectors, provider()...)
+	}
+	return detectors
+}
+
+// Locales returns a sorted list of all supported locale names.
+func Locales() []string {
+	locales := make([]string, 0, len(localeProviders))
+	for k := range localeProviders {
+		locales = append(locales, k)
+	}
+	sort.Strings(locales)
+	return locales
+}

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -1,0 +1,71 @@
+package registry
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestAllDetectors(t *testing.T) {
+	detectors := AllDetectors()
+	if len(detectors) == 0 {
+		t.Fatal("AllDetectors() returned 0 detectors, expected > 0")
+	}
+}
+
+func TestAllDetectorsNoDuplicates(t *testing.T) {
+	detectors := AllDetectors()
+	seen := make(map[string]bool)
+	for _, d := range detectors {
+		if seen[d.Name()] {
+			t.Errorf("duplicate detector: %s", d.Name())
+		}
+		seen[d.Name()] = true
+	}
+}
+
+func TestDetectorsForLocale(t *testing.T) {
+	nlDetectors := DetectorsForLocale("nl")
+	if len(nlDetectors) == 0 {
+		t.Fatal("DetectorsForLocale(\"nl\") returned 0 detectors")
+	}
+
+	// Should include common detectors.
+	commonDetectors := DetectorsForLocale("common")
+	if len(nlDetectors) <= len(commonDetectors) {
+		t.Errorf("nl detectors (%d) should be more than common-only (%d)",
+			len(nlDetectors), len(commonDetectors))
+	}
+
+	// Verify common detectors are present in the nl set.
+	nlNames := make(map[string]bool)
+	for _, d := range nlDetectors {
+		nlNames[d.Name()] = true
+	}
+	for _, d := range commonDetectors {
+		if !nlNames[d.Name()] {
+			t.Errorf("common detector %q missing from nl locale", d.Name())
+		}
+	}
+}
+
+func TestDetectorsForLocaleUnknown(t *testing.T) {
+	detectors := DetectorsForLocale("xx")
+	commonDetectors := DetectorsForLocale("common")
+	if len(detectors) != len(commonDetectors) {
+		t.Errorf("unknown locale should return only common detectors: got %d, want %d",
+			len(detectors), len(commonDetectors))
+	}
+}
+
+func TestLocales(t *testing.T) {
+	locales := Locales()
+	expected := []string{"common", "de", "eu", "fr", "gb", "nl", "us"}
+	if len(locales) != len(expected) {
+		t.Fatalf("Locales() = %v, want %v", locales, expected)
+	}
+	for _, e := range expected {
+		if !slices.Contains(locales, e) {
+			t.Errorf("Locales() missing %q", e)
+		}
+	}
+}

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,9 +2,35 @@
 
 This guide walks through the most common usage patterns for wuming.
 
-## Basic Usage
+## Zero-Config (Recommended)
 
-The simplest way to use wuming is with the default configuration, which loads all available detectors and uses the redact replacer:
+The fastest way to get started — a single function call that uses all available detectors:
+
+```go
+ctx := context.Background()
+
+// One-liner: detect and redact all PII.
+redacted, err := wuming.Redact(ctx, "SSN 123-45-6789, email john@acme.com")
+// redacted: "SSN [NATIONAL_ID], email [EMAIL]"
+```
+
+You can also get match details:
+
+```go
+matches, err := wuming.Detect(ctx, "BSN 123456782, call 06-12345678")
+// matches contains all detected PII with type, confidence, position
+```
+
+Or the full result:
+
+```go
+result, err := wuming.Process(ctx, text)
+// result.Original, result.Redacted, result.Matches, result.MatchCount
+```
+
+## Custom Instance
+
+Create a configured instance for more control:
 
 ```go
 w := wuming.New()

--- a/wuming.go
+++ b/wuming.go
@@ -17,7 +17,9 @@ package wuming
 
 import (
 	"context"
+	"sync"
 
+	"github.com/taoq-ai/wuming/adapter/registry"
 	"github.com/taoq-ai/wuming/adapter/replacer"
 	"github.com/taoq-ai/wuming/domain/model"
 	"github.com/taoq-ai/wuming/domain/port"
@@ -92,6 +94,11 @@ func New(opts ...Option) *Wuming {
 		opt(cfg)
 	}
 
+	// Default to all detectors if none explicitly provided.
+	if len(cfg.detectors) == 0 {
+		cfg.detectors = registry.AllDetectors()
+	}
+
 	// Default replacer.
 	if cfg.replacer == nil {
 		cfg.replacer = replacer.NewRedact()
@@ -139,4 +146,32 @@ func (w *Wuming) Redact(ctx context.Context, text string) (string, error) {
 		return "", err
 	}
 	return result.Redacted, nil
+}
+
+// defaultInstance is lazily initialized with all detectors.
+var (
+	defaultOnce     sync.Once
+	defaultInstance *Wuming
+)
+
+func getDefault() *Wuming {
+	defaultOnce.Do(func() {
+		defaultInstance = New()
+	})
+	return defaultInstance
+}
+
+// Redact detects and redacts all PII from text using all available detectors.
+func Redact(ctx context.Context, text string) (string, error) {
+	return getDefault().Redact(ctx, text)
+}
+
+// Detect finds all PII matches in text using all available detectors.
+func Detect(ctx context.Context, text string) ([]model.Match, error) {
+	return getDefault().Detect(ctx, text)
+}
+
+// Process runs full PII detection and replacement using all available detectors.
+func Process(ctx context.Context, text string) (*port.Result, error) {
+	return getDefault().Process(ctx, text)
 }

--- a/wuming_test.go
+++ b/wuming_test.go
@@ -2,6 +2,7 @@ package wuming
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/taoq-ai/wuming/domain/model"
@@ -84,3 +85,63 @@ func TestWumingProcess(t *testing.T) {
 
 // Verify stub implements port.Detector.
 var _ port.Detector = (*stubDetector)(nil)
+
+func TestZeroConfigNew(t *testing.T) {
+	w := New()
+	text := "Email john@example.com and SSN 078-05-1120"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MatchCount == 0 {
+		t.Error("zero-config New() should detect PII, but found no matches")
+	}
+}
+
+func TestPackageLevelRedact(t *testing.T) {
+	got, err := Redact(context.Background(), "Email john@example.com please")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "Email john@example.com please" {
+		t.Error("package-level Redact() did not redact anything")
+	}
+}
+
+func TestPackageLevelDetect(t *testing.T) {
+	matches, err := Detect(context.Background(), "Email john@example.com please")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Error("package-level Detect() found no matches")
+	}
+}
+
+func TestWithLocaleFilters(t *testing.T) {
+	w := New(WithLocale("nl"))
+	// BSN should be detected, SSN should not (US-specific).
+	text := "BSN: 123456782, SSN: 078-05-1120"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hasNL := false
+	hasUS := false
+	for _, m := range result.Matches {
+		if strings.HasPrefix(m.Detector, "nl/") {
+			hasNL = true
+		}
+		if strings.HasPrefix(m.Detector, "us/") {
+			hasUS = true
+		}
+	}
+
+	if !hasNL {
+		t.Error("WithLocale(\"nl\") should detect NL PII")
+	}
+	if hasUS {
+		t.Error("WithLocale(\"nl\") should not detect US-specific PII")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `All()` helper to each locale package (common, us, nl, eu, gb, de, fr)
- Create `adapter/registry` package aggregating all detectors
- `wuming.New()` now defaults to all detectors when none specified (zero-config)
- Add package-level `wuming.Redact()`, `wuming.Detect()`, `wuming.Process()` convenience functions
- Update quickstart docs and README with simplified usage examples
- Update example in `_examples/basic/`

Closes #57

## Usage after this PR
```go
// Zero config — one line, catches everything
redacted, _ := wuming.Redact(ctx, "SSN 123-45-6789, email john@acme.com")

// Locale-specific
w := wuming.New(wuming.WithLocale("nl"))
result, _ := w.Process(ctx, text)
```

## Test plan
- [ ] `go test ./...` passes
- [ ] Zero-config `New()` detects PII from all locales
- [ ] Package-level functions work correctly
- [ ] `WithLocale()` still filters properly
- [ ] Registry returns no duplicate detectors