### PR TITLE
feat: add Japan PII detectors

### DIFF
--- a/adapter/detector/jp/all.go
+++ b/adapter/detector/jp/all.go
@@ -1,0 +1,14 @@
+package jp
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all Japan locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewMyNumberDetector(),
+		NewCorporateNumberDetector(),
+		NewPhoneDetector(),
+		NewPostalDetector(),
+		NewPassportDetector(),
+	}
+}

--- a/adapter/detector/jp/corporate_number.go
+++ b/adapter/detector/jp/corporate_number.go
@@ -1,0 +1,68 @@
+package jp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 13 consecutive digits.
+var corporateNumberRe = regexp.MustCompile(`\b\d{13}\b`)
+
+// CorporateNumberDetector detects Japanese Corporate Numbers (法人番号).
+type CorporateNumberDetector struct{}
+
+func NewCorporateNumberDetector() *CorporateNumberDetector { return &CorporateNumberDetector{} }
+
+func (d *CorporateNumberDetector) Name() string              { return "jp/corporate_number" }
+func (d *CorporateNumberDetector) Locales() []string         { return []string{locale} }
+func (d *CorporateNumberDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *CorporateNumberDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := corporateNumberRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		candidate := text[loc[0]:loc[1]]
+		if !isValidCorporateNumber(candidate) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      candidate,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.80,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidCorporateNumber verifies the check digit of a 13-digit Corporate Number.
+// The first digit is the check digit: 9 - (weighted sum of digits 2-13 mod 9).
+// Weights alternate 1, 2, 1, 2, ... for positions 2-13 (left to right).
+func isValidCorporateNumber(s string) bool {
+	if len(s) != 13 {
+		return false
+	}
+
+	var sum int
+	for i := 1; i < 13; i++ {
+		digit := int(s[i] - '0')
+		// Positions 2-13 (1-indexed): odd positions get weight 1, even get weight 2.
+		if i%2 == 1 {
+			sum += digit * 1
+		} else {
+			sum += digit * 2
+		}
+	}
+
+	check := 9 - (sum % 9)
+	return int(s[0]-'0') == check
+}

--- a/adapter/detector/jp/helpers.go
+++ b/adapter/detector/jp/helpers.go
@@ -1,0 +1,31 @@
+// Package jp provides PII detectors for Japan-specific patterns.
+package jp
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "jp"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/jp/jp_test.go
+++ b/adapter/detector/jp/jp_test.go
@@ -1,0 +1,204 @@
+package jp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*MyNumberDetector)(nil)
+	_ port.Detector = (*CorporateNumberDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostalDetector)(nil)
+	_ port.Detector = (*PassportDetector)(nil)
+)
+
+func TestMyNumberDetector(t *testing.T) {
+	d := NewMyNumberDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"My Number: 123456789018", 1, "valid My Number"},
+		{"番号: 000000000000", 1, "all zeros valid"},
+		{"123456789019", 0, "invalid check digit"},
+		{"12345678901", 0, "too short (11 digits)"},
+		{"1234567890123", 0, "too long (13 digits)"},
+		{"no number here", 0, "no My Number"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "jp" {
+				t.Errorf("expected locale 'jp', got %q", m.Locale)
+			}
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.85 {
+				t.Errorf("expected confidence 0.85, got %v", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestCorporateNumberDetector(t *testing.T) {
+	d := NewCorporateNumberDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"法人番号: 3234567890123", 1, "valid corporate number"},
+		{"9000000000000", 1, "valid all zeros body"},
+		{"1234567890123", 0, "invalid check digit"},
+		{"234567890123", 0, "too short (12 digits)"},
+		{"no corp number", 0, "no corporate number"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.80 {
+				t.Errorf("expected confidence 0.80, got %v", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Call 090-1234-5678", 1, "mobile 090"},
+		{"080-1234-5678", 1, "mobile 080"},
+		{"070-1234-5678", 1, "mobile 070"},
+		{"+81 90-1234-5678", 1, "international mobile"},
+		{"03-1234-5678", 1, "Tokyo landline"},
+		{"06-1234-5678", 1, "Osaka landline"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+			if m.Confidence != 0.85 {
+				t.Errorf("expected confidence 0.85, got %v", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPostalDetector(t *testing.T) {
+	d := NewPostalDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"〒100-0001", 1, "with postal mark"},
+		{"100-0001", 1, "without postal mark"},
+		{"〒 123-4567", 1, "postal mark with space"},
+		{"1234567", 0, "no hyphen"},
+		{"no postal here", 0, "no postal code"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+			if m.Confidence != 0.75 {
+				t.Errorf("expected confidence 0.75, got %v", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPassportDetector(t *testing.T) {
+	d := NewPassportDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Passport: TK1234567", 1, "standard format"},
+		{"MZ9876543", 1, "another valid format"},
+		{"A1234567", 0, "only 1 letter"},
+		{"TK123456", 0, "too few digits"},
+		{"TK12345678", 0, "too many digits"},
+		{"no passport", 0, "no passport"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Passport {
+				t.Errorf("expected Passport type, got %v", m.Type)
+			}
+			if m.Confidence != 0.70 {
+				t.Errorf("expected confidence 0.70, got %v", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	detectors := All()
+	if len(detectors) != 5 {
+		t.Errorf("All() returned %d detectors, want 5", len(detectors))
+	}
+}

--- a/adapter/detector/jp/my_number.go
+++ b/adapter/detector/jp/my_number.go
@@ -1,0 +1,71 @@
+package jp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 12 consecutive digits.
+var myNumberRe = regexp.MustCompile(`\b\d{12}\b`)
+
+// myNumberWeights are the weights for positions 1-11 (left to right) used in
+// the check-digit calculation for the Japanese My Number (マイナンバー).
+var myNumberWeights = [11]int{6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2}
+
+// MyNumberDetector detects Japanese My Number (個人番号) identifiers.
+type MyNumberDetector struct{}
+
+func NewMyNumberDetector() *MyNumberDetector { return &MyNumberDetector{} }
+
+func (d *MyNumberDetector) Name() string              { return "jp/my_number" }
+func (d *MyNumberDetector) Locales() []string         { return []string{locale} }
+func (d *MyNumberDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *MyNumberDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := myNumberRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		candidate := text[loc[0]:loc[1]]
+		if !isValidMyNumber(candidate) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      candidate,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidMyNumber verifies the check digit of a 12-digit My Number.
+// Check digit = 11 - (weighted sum mod 11); if >= 10, check digit is 0.
+func isValidMyNumber(s string) bool {
+	if len(s) != 12 {
+		return false
+	}
+
+	var sum int
+	for i := 0; i < 11; i++ {
+		digit := int(s[i] - '0')
+		sum += digit * myNumberWeights[i]
+	}
+
+	remainder := sum % 11
+	check := 11 - remainder
+	if check >= 10 {
+		check = 0
+	}
+
+	return int(s[11]-'0') == check
+}

--- a/adapter/detector/jp/passport.go
+++ b/adapter/detector/jp/passport.go
@@ -1,0 +1,24 @@
+package jp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Japanese passport: 2 uppercase letters followed by 7 digits (e.g. TK1234567).
+var jpPassportRe = regexp.MustCompile(`\b[A-Z]{2}\d{7}\b`)
+
+// PassportDetector detects Japanese passport numbers.
+type PassportDetector struct{}
+
+func NewPassportDetector() *PassportDetector { return &PassportDetector{} }
+
+func (d *PassportDetector) Name() string              { return "jp/passport" }
+func (d *PassportDetector) Locales() []string         { return []string{locale} }
+func (d *PassportDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Passport} }
+
+func (d *PassportDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(jpPassportRe, text, model.Passport, 0.70, d.Name()), nil
+}

--- a/adapter/detector/jp/phone.go
+++ b/adapter/detector/jp/phone.go
@@ -1,0 +1,31 @@
+package jp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Japanese phone numbers:
+// - Mobile: 090/080/070-XXXX-XXXX (with optional +81 prefix)
+// - Landline: 0X-XXXX-XXXX or 0XX-XXX-XXXX (common area codes)
+// - International: +81 X0-XXXX-XXXX
+var jpPhoneRe = regexp.MustCompile(
+	`(?:\+81[\s-]?[0-9]{1,2}[\s-]?[0-9]{4}[\s-]?[0-9]{4})` + // +81 format
+		`|(?:0[789]0[\s-]?[0-9]{4}[\s-]?[0-9]{4})` + // mobile 090/080/070
+		`|(?:0[1-9][0-9]{0,3}[\s-]?[0-9]{2,4}[\s-]?[0-9]{4})`, // landline
+)
+
+// PhoneDetector detects Japanese phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "jp/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(jpPhoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/jp/postal.go
+++ b/adapter/detector/jp/postal.go
@@ -1,0 +1,24 @@
+package jp
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Japanese postal code: optional 〒 prefix, 3 digits, hyphen, 4 digits.
+var postalRe = regexp.MustCompile(`(?:〒\s?)?\b\d{3}-\d{4}\b`)
+
+// PostalDetector detects Japanese postal codes (郵便番号).
+type PostalDetector struct{}
+
+func NewPostalDetector() *PostalDetector { return &PostalDetector{} }
+
+func (d *PostalDetector) Name() string              { return "jp/postal" }
+func (d *PostalDetector) Locales() []string         { return []string{locale} }
+func (d *PostalDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostalDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(postalRe, text, model.PostalCode, 0.75, d.Name()), nil
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/taoq-ai/wuming/adapter/detector/eu"
 	"github.com/taoq-ai/wuming/adapter/detector/fr"
 	"github.com/taoq-ai/wuming/adapter/detector/gb"
+	"github.com/taoq-ai/wuming/adapter/detector/jp"
 	"github.com/taoq-ai/wuming/adapter/detector/nl"
 	"github.com/taoq-ai/wuming/adapter/detector/us"
 	"github.com/taoq-ai/wuming/domain/port"
@@ -24,6 +25,7 @@ var localeProviders = map[string]func() []port.Detector{
 	"gb":     gb.All,
 	"de":     de.All,
 	"fr":     fr.All,
+	"jp":     jp.All,
 }
 
 // AllDetectors returns every registered PII detector across all locales.

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -59,7 +59,7 @@ func TestDetectorsForLocaleUnknown(t *testing.T) {
 
 func TestLocales(t *testing.T) {
 	locales := Locales()
-	expected := []string{"common", "de", "eu", "fr", "gb", "nl", "us"}
+	expected := []string{"common", "de", "eu", "fr", "gb", "jp", "nl", "us"}
 	if len(locales) != len(expected) {
 		t.Fatalf("Locales() = %v, want %v", locales, expected)
 	}


### PR DESCRIPTION
## Summary
- Add `adapter/detector/jp/` package with five Japan-specific PII detectors: My Number (individual), Corporate Number, phone, postal code, and passport
- Each detector follows the same pattern as existing locale packages (us, nl, etc.) with proper check-digit validation for My Number and Corporate Number
- Register the `jp` locale in the detector registry

## Detectors
| Detector | PIIType | Confidence | Validation |
|----------|---------|------------|------------|
| My Number (マイナンバー) | NationalID | 0.85 | 12-digit with weighted check digit |
| Corporate Number (法人番号) | TaxID | 0.80 | 13-digit with check digit |
| Phone | Phone | 0.85 | Mobile (090/080/070), landline, +81 international |
| Postal Code (郵便番号) | PostalCode | 0.75 | XXX-XXXX with optional 〒 prefix |
| Passport | Passport | 0.70 | 2 letters + 7 digits |

## Test plan
- [x] All JP detector unit tests pass (`go test ./adapter/detector/jp/`)
- [x] Registry test updated and passing (`go test ./adapter/registry/`)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

Closes #15