### PR TITLE
feat: add South Korea PII detectors (RRN, phone, postal, passport)

### DIFF
--- a/adapter/detector/kr/all.go
+++ b/adapter/detector/kr/all.go
@@ -1,0 +1,13 @@
+package kr
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all South Korea locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewRRNDetector(),
+		NewPhoneDetector(),
+		NewPostalDetector(),
+		NewPassportDetector(),
+	}
+}

--- a/adapter/detector/kr/helpers.go
+++ b/adapter/detector/kr/helpers.go
@@ -1,0 +1,31 @@
+// Package kr provides PII detectors for South Korea-specific patterns.
+package kr
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "kr"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/kr/kr_test.go
+++ b/adapter/detector/kr/kr_test.go
@@ -1,0 +1,177 @@
+package kr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*RRNDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostalDetector)(nil)
+	_ port.Detector = (*PassportDetector)(nil)
+)
+
+func TestRRNDetector(t *testing.T) {
+	d := NewRRNDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"RRN: 900101-1000006", 1, "valid male 1900s"},
+		{"850515-2123451", 1, "valid female 1900s"},
+		{"000101-3000008", 1, "valid male 2000s"},
+		{"900101-1000007", 0, "invalid check digit"},
+		{"000000-1234567", 0, "invalid date 000000"},
+		{"901301-1000001", 0, "invalid month 13"},
+		{"900100-1000001", 0, "invalid day 00"},
+		{"900101-9000001", 0, "invalid gender digit 9"},
+		{"no rrn here", 0, "no RRN"},
+		{"12345-1234567", 0, "only 5 digit date prefix"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "kr" {
+				t.Errorf("expected locale 'kr', got %q", m.Locale)
+			}
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.90 {
+				t.Errorf("expected confidence 0.90, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Call 010-1234-5678", 1, "mobile with dashes"},
+		{"010 1234 5678", 1, "mobile with spaces"},
+		{"+82 10-1234-5678", 1, "mobile international prefix"},
+		{"+82-10-1234-5678", 1, "mobile international with dash"},
+		{"02-123-4567", 1, "Seoul landline 7-digit"},
+		{"02-1234-5678", 1, "Seoul landline 8-digit"},
+		{"031-123-4567", 1, "Gyeonggi landline"},
+		{"051-1234-5678", 1, "Busan landline"},
+		{"123-4567", 0, "too short, no area code"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+			if m.Confidence != 0.85 {
+				t.Errorf("expected confidence 0.85, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPostalDetector(t *testing.T) {
+	d := NewPostalDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Postal: 06236", 1, "valid Seoul postal code"},
+		{"48058", 1, "valid Busan postal code"},
+		{"1234", 0, "too short"},
+		{"123456", 0, "too long"},
+		{"no postal code", 0, "no postal code"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+			if m.Confidence != 0.50 {
+				t.Errorf("expected confidence 0.50, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPassportDetector(t *testing.T) {
+	d := NewPassportDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Passport: M12345678", 1, "regular passport"},
+		{"R12345678", 1, "residence passport letter"},
+		{"S98765432", 1, "other letter prefix"},
+		{"12345678", 0, "no letter prefix"},
+		{"AB12345678", 0, "two letter prefix"},
+		{"M1234567", 0, "too few digits"},
+		{"no passport here", 0, "no passport"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Passport {
+				t.Errorf("expected Passport type, got %v", m.Type)
+			}
+			if m.Confidence != 0.70 {
+				t.Errorf("expected confidence 0.70, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	detectors := All()
+	if len(detectors) != 4 {
+		t.Errorf("All() returned %d detectors, want 4", len(detectors))
+	}
+}

--- a/adapter/detector/kr/passport.go
+++ b/adapter/detector/kr/passport.go
@@ -1,0 +1,25 @@
+package kr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Korean passport: single uppercase letter followed by 8 digits.
+// Regular passports start with M; other types use various letters.
+var passportRe = regexp.MustCompile(`\b[A-Z]\d{8}\b`)
+
+// PassportDetector detects South Korean passport numbers.
+type PassportDetector struct{}
+
+func NewPassportDetector() *PassportDetector { return &PassportDetector{} }
+
+func (d *PassportDetector) Name() string              { return "kr/passport" }
+func (d *PassportDetector) Locales() []string         { return []string{locale} }
+func (d *PassportDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Passport} }
+
+func (d *PassportDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(passportRe, text, model.Passport, 0.70, d.Name()), nil
+}

--- a/adapter/detector/kr/phone.go
+++ b/adapter/detector/kr/phone.go
@@ -1,0 +1,35 @@
+package kr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Korean phone numbers:
+// Mobile: 010-XXXX-XXXX (with optional +82 prefix)
+// Seoul landline: 02-XXX(X)-XXXX
+// Other landline: 0XX-XXX(X)-XXXX
+var phoneRe = regexp.MustCompile(
+	`(?:` +
+		`\+82[\s-]?10[\s-]?\d{4}[\s-]?\d{4}` + // international mobile (+82 10-XXXX-XXXX)
+		`|\+82[\s-]?2[\s-]?\d{3,4}[\s-]?\d{4}` + // international Seoul (+82 2-XXX-XXXX)
+		`|\+82[\s-]?[3-6][1-9][\s-]?\d{3,4}[\s-]?\d{4}` + // international other landline
+		`|010[\s-]?\d{4}[\s-]?\d{4}` + // domestic mobile
+		`|02[\s-]?\d{3,4}[\s-]?\d{4}` + // domestic Seoul landline
+		`|0[3-6][1-9][\s-]?\d{3,4}[\s-]?\d{4}` + // domestic other landline
+		`)`)
+
+// PhoneDetector detects South Korean phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "kr/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(phoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/kr/postal.go
+++ b/adapter/detector/kr/postal.go
@@ -1,0 +1,24 @@
+package kr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Korean postal code: 5 digits (new system since 2015).
+var postalRe = regexp.MustCompile(`\b\d{5}\b`)
+
+// PostalDetector detects South Korean postal codes.
+type PostalDetector struct{}
+
+func NewPostalDetector() *PostalDetector { return &PostalDetector{} }
+
+func (d *PostalDetector) Name() string              { return "kr/postal" }
+func (d *PostalDetector) Locales() []string         { return []string{locale} }
+func (d *PostalDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostalDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(postalRe, text, model.PostalCode, 0.50, d.Name()), nil
+}

--- a/adapter/detector/kr/rrn.go
+++ b/adapter/detector/kr/rrn.go
@@ -1,0 +1,70 @@
+package kr
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Korean Resident Registration Number: YYMMDD-GNNNNNN (13 digits with hyphen).
+var rrnRe = regexp.MustCompile(`\b(\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])-([1-8])(\d{6})\b`)
+
+// RRNDetector detects South Korean Resident Registration Numbers.
+type RRNDetector struct{}
+
+func NewRRNDetector() *RRNDetector { return &RRNDetector{} }
+
+func (d *RRNDetector) Name() string              { return "kr/rrn" }
+func (d *RRNDetector) Locales() []string         { return []string{locale} }
+func (d *RRNDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *RRNDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := rrnRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		full := text[loc[0]:loc[1]]
+		if !isValidRRN(full) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      full,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidRRN validates the RRN check digit.
+// The 13th digit = (11 - (weighted sum mod 11)) mod 10.
+// Weights: [2,3,4,5,6,7,8,9,2,3,4,5] applied to the first 12 digits.
+func isValidRRN(rrn string) bool {
+	// Remove the hyphen to get 13 raw digits.
+	digits := make([]int, 0, 13)
+	for _, c := range rrn {
+		if c == '-' {
+			continue
+		}
+		digits = append(digits, int(c-'0'))
+	}
+	if len(digits) != 13 {
+		return false
+	}
+
+	weights := []int{2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5}
+	sum := 0
+	for i := 0; i < 12; i++ {
+		sum += digits[i] * weights[i]
+	}
+	check := (11 - (sum % 11)) % 10
+	return check == digits[12]
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/taoq-ai/wuming/adapter/detector/fr"
 	"github.com/taoq-ai/wuming/adapter/detector/gb"
 	"github.com/taoq-ai/wuming/adapter/detector/jp"
+	"github.com/taoq-ai/wuming/adapter/detector/kr"
 	"github.com/taoq-ai/wuming/adapter/detector/nl"
 	"github.com/taoq-ai/wuming/adapter/detector/us"
 	"github.com/taoq-ai/wuming/domain/port"
@@ -23,6 +24,7 @@ var localeProviders = map[string]func() []port.Detector{
 	"nl":     nl.All,
 	"eu":     eu.All,
 	"gb":     gb.All,
+	"kr":     kr.All,
 	"de":     de.All,
 	"fr":     fr.All,
 	"jp":     jp.All,

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -59,7 +59,7 @@ func TestDetectorsForLocaleUnknown(t *testing.T) {
 
 func TestLocales(t *testing.T) {
 	locales := Locales()
-	expected := []string{"common", "de", "eu", "fr", "gb", "jp", "nl", "us"}
+	expected := []string{"common", "de", "eu", "fr", "gb", "jp", "kr", "nl", "us"}
 	if len(locales) != len(expected) {
 		t.Fatalf("Locales() = %v, want %v", locales, expected)
 	}


### PR DESCRIPTION
## Summary
- Adds new `adapter/detector/kr/` package with four South Korea-specific PII detectors
- **RRN** (Resident Registration Number): validates YYMMDD-GNNNNNN format with gender digit and weighted check digit (confidence 0.90)
- **Phone**: supports mobile (010-XXXX-XXXX), Seoul landline (02-XXX-XXXX), regional landlines, and +82 international prefix (confidence 0.85)
- **Postal code**: 5-digit new system format (confidence 0.50)
- **Passport**: single uppercase letter + 8 digits, e.g. M12345678 (confidence 0.70)
- Registers `kr` locale in the detector registry

Closes #18

## Test plan
- [x] `go test ./...` passes (all existing + new kr tests)
- [x] `go vet ./...` clean
- [ ] Review RRN check digit validation against known valid/invalid numbers
- [ ] Verify phone regex covers edge cases for Korean area codes