### PR TITLE
feat: add Australia PII detectors (TFN, Medicare, ABN, phone, postcode)

### DIFF
--- a/adapter/detector/au/abn.go
+++ b/adapter/detector/au/abn.go
@@ -1,0 +1,72 @@
+package au
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// ABN: 11 digits, optionally separated by spaces or dashes.
+var abnRe = regexp.MustCompile(`\b(\d[ \-]?){10}\d\b`)
+
+// ABNDetector detects Australian Business Numbers.
+type ABNDetector struct{}
+
+func NewABNDetector() *ABNDetector { return &ABNDetector{} }
+
+func (d *ABNDetector) Name() string              { return "au/abn" }
+func (d *ABNDetector) Locales() []string         { return []string{locale} }
+func (d *ABNDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *ABNDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := abnRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		if !isValidABN(raw) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidABN validates using the ABN algorithm:
+// subtract 1 from first digit, apply weights, sum mod 89 must equal 0.
+func isValidABN(raw string) bool {
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, raw)
+
+	if len(digits) != 11 {
+		return false
+	}
+
+	weights := [11]int{10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19}
+	sum := 0
+	for i, ch := range digits {
+		d := int(ch - '0')
+		if i == 0 {
+			d-- // subtract 1 from first digit
+		}
+		sum += d * weights[i]
+	}
+	return sum%89 == 0
+}

--- a/adapter/detector/au/all.go
+++ b/adapter/detector/au/all.go
@@ -1,0 +1,14 @@
+package au
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all Australian locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewTFNDetector(),
+		NewMedicareDetector(),
+		NewABNDetector(),
+		NewPhoneDetector(),
+		NewPostcodeDetector(),
+	}
+}

--- a/adapter/detector/au/au_test.go
+++ b/adapter/detector/au/au_test.go
@@ -1,0 +1,197 @@
+package au
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*TFNDetector)(nil)
+	_ port.Detector = (*MedicareDetector)(nil)
+	_ port.Detector = (*ABNDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostcodeDetector)(nil)
+)
+
+func TestTFNDetector(t *testing.T) {
+	d := NewTFNDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"TFN: 123 456 782", 1, "valid TFN with spaces"},
+		{"123456782", 1, "valid TFN no separators"},
+		{"987-654-303", 1, "valid TFN with dashes"},
+		{"123 456 789", 0, "invalid checksum"},
+		{"12345678", 0, "too few digits"},
+		{"no tfn here", 0, "no TFN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "au" {
+				t.Errorf("expected locale 'au', got %q", m.Locale)
+			}
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestMedicareDetector(t *testing.T) {
+	d := NewMedicareDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Medicare: 2123 45670 1", 1, "valid Medicare with issue number"},
+		{"21234567 01", 1, "valid Medicare with space before issue"},
+		{"2123456701", 1, "valid Medicare no separators"},
+		{"1123456789", 0, "invalid: first digit 1"},
+		{"7123456789", 0, "invalid: first digit 7"},
+		{"no medicare", 0, "no Medicare number"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.HealthID {
+				t.Errorf("expected HealthID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestABNDetector(t *testing.T) {
+	d := NewABNDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"ABN: 51 824 753 556", 1, "valid ABN with spaces"},
+		{"51824753556", 1, "valid ABN no separators"},
+		{"53 004 085 616", 1, "valid ABN (Telstra)"},
+		{"12 345 678 901", 0, "invalid checksum"},
+		{"no abn here", 0, "no ABN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Call 0412 345 678", 1, "mobile with spaces"},
+		{"+61 412 345 678", 1, "international mobile"},
+		{"(02) 1234 5678", 1, "landline with parens"},
+		{"+61 2 1234 5678", 1, "international landline"},
+		{"0412345678", 1, "mobile no separators"},
+		{"123-456", 0, "too short"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPostcodeDetector(t *testing.T) {
+	d := NewPostcodeDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Sydney 2000", 1, "NSW postcode"},
+		{"Melbourne 3000", 1, "VIC postcode"},
+		{"Brisbane 4000", 1, "QLD postcode"},
+		{"Adelaide 5000", 1, "SA postcode"},
+		{"Perth 6000", 1, "WA postcode"},
+		{"Hobart 7000", 1, "TAS postcode"},
+		{"Darwin 0800", 1, "NT postcode"},
+		{"Canberra 2600", 1, "ACT postcode"},
+		{"0001", 0, "invalid: below range"},
+		{"no postcode here", 0, "no postcode"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+			if m.Confidence != 0.55 {
+				t.Errorf("expected confidence 0.55, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	detectors := All()
+	if len(detectors) != 5 {
+		t.Errorf("All() returned %d detectors, want 5", len(detectors))
+	}
+}

--- a/adapter/detector/au/helpers.go
+++ b/adapter/detector/au/helpers.go
@@ -1,0 +1,31 @@
+// Package au provides PII detectors for Australian-specific patterns.
+package au
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "au"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/au/medicare.go
+++ b/adapter/detector/au/medicare.go
@@ -1,0 +1,73 @@
+package au
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Medicare number: 10 base digits + optional 1-digit issue number, with optional separators.
+var medicareRe = regexp.MustCompile(`\b(\d[ \-]?){9}\d(\d)?\b`)
+
+// MedicareDetector detects Australian Medicare card numbers.
+type MedicareDetector struct{}
+
+func NewMedicareDetector() *MedicareDetector { return &MedicareDetector{} }
+
+func (d *MedicareDetector) Name() string              { return "au/medicare" }
+func (d *MedicareDetector) Locales() []string         { return []string{locale} }
+func (d *MedicareDetector) PIITypes() []model.PIIType { return []model.PIIType{model.HealthID} }
+
+func (d *MedicareDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := medicareRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		if !isValidMedicare(raw) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.HealthID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidMedicare checks the Medicare check digit.
+// Weights [1,3,7,9,1,3,7,9] on first 8 digits; sum mod 10 must equal the 9th digit.
+func isValidMedicare(raw string) bool {
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, raw)
+
+	if len(digits) < 10 || len(digits) > 11 {
+		return false
+	}
+
+	// First digit must be 2-6 (valid Medicare card range).
+	if digits[0] < '2' || digits[0] > '6' {
+		return false
+	}
+
+	weights := [8]int{1, 3, 7, 9, 1, 3, 7, 9}
+	sum := 0
+	for i := 0; i < 8; i++ {
+		sum += int(digits[i]-'0') * weights[i]
+	}
+	return sum%10 == int(digits[8]-'0')
+}

--- a/adapter/detector/au/phone.go
+++ b/adapter/detector/au/phone.go
@@ -1,0 +1,33 @@
+package au
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Australian phone patterns:
+// Mobile:   04XX XXX XXX or +61 4XX XXX XXX
+// Landline: (0X) XXXX XXXX or +61 X XXXX XXXX
+var auPhoneRe = regexp.MustCompile(
+	`(?:` +
+		`\+61[\s\-]?4\d{2}[\s\-]?\d{3}[\s\-]?\d{3}` + // +61 mobile
+		`|04\d{2}[\s\-]?\d{3}[\s\-]?\d{3}` + // 04XX mobile
+		`|\+61[\s\-]?[2-9][\s\-]?\d{4}[\s\-]?\d{4}` + // +61 landline
+		`|\(0[2-9]\)[\s\-]?\d{4}[\s\-]?\d{4}` + // (0X) landline
+		`)`,
+)
+
+// PhoneDetector detects Australian phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "au/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(auPhoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/au/postcode.go
+++ b/adapter/detector/au/postcode.go
@@ -1,0 +1,76 @@
+package au
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// 4-digit postcode pattern.
+var postcodeRe = regexp.MustCompile(`\b\d{4}\b`)
+
+// PostcodeDetector detects Australian postcodes.
+type PostcodeDetector struct{}
+
+func NewPostcodeDetector() *PostcodeDetector { return &PostcodeDetector{} }
+
+func (d *PostcodeDetector) Name() string              { return "au/postcode" }
+func (d *PostcodeDetector) Locales() []string         { return []string{locale} }
+func (d *PostcodeDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostcodeDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	locs := postcodeRe.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range locs {
+		raw := text[loc[0]:loc[1]]
+		if !isValidAUPostcode(raw) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.PostalCode,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.55,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidAUPostcode checks whether a 4-digit string falls within a valid
+// Australian postcode range.
+func isValidAUPostcode(s string) bool {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return false
+	}
+
+	switch {
+	case n >= 800 && n <= 999: // NT
+		return true
+	case n >= 1000 && n <= 2999: // NSW
+		return true
+	case n >= 3000 && n <= 3999: // VIC
+		return true
+	case n >= 4000 && n <= 4999: // QLD
+		return true
+	case n >= 5000 && n <= 5999: // SA
+		return true
+	case n >= 6000 && n <= 6999: // WA
+		return true
+	case n >= 7000 && n <= 7999: // TAS
+		return true
+	default:
+		return false
+	}
+	// Note: ACT postcodes (2600-2639, 2900-2920) are covered by the NSW
+	// 1000-2999 range above, so they are valid.
+}

--- a/adapter/detector/au/tfn.go
+++ b/adapter/detector/au/tfn.go
@@ -1,0 +1,68 @@
+package au
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// TFN: 9 digits, optionally separated by spaces or dashes.
+var tfnRe = regexp.MustCompile(`\b(\d[ \-]?){8}\d\b`)
+
+// TFNDetector detects Australian Tax File Numbers.
+type TFNDetector struct{}
+
+func NewTFNDetector() *TFNDetector { return &TFNDetector{} }
+
+func (d *TFNDetector) Name() string              { return "au/tfn" }
+func (d *TFNDetector) Locales() []string         { return []string{locale} }
+func (d *TFNDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *TFNDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := tfnRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		if !isValidTFN(raw) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidTFN checks the TFN weighted checksum.
+// Weights: [1,4,3,7,5,8,6,9,10], sum mod 11 must equal 0.
+func isValidTFN(raw string) bool {
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, raw)
+
+	if len(digits) != 9 {
+		return false
+	}
+
+	weights := [9]int{1, 4, 3, 7, 5, 8, 6, 9, 10}
+	sum := 0
+	for i, ch := range digits {
+		sum += int(ch-'0') * weights[i]
+	}
+	return sum%11 == 0
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -5,6 +5,7 @@ package registry
 import (
 	"sort"
 
+	"github.com/taoq-ai/wuming/adapter/detector/au"
 	"github.com/taoq-ai/wuming/adapter/detector/common"
 	"github.com/taoq-ai/wuming/adapter/detector/de"
 	"github.com/taoq-ai/wuming/adapter/detector/eu"
@@ -19,15 +20,16 @@ import (
 
 // localeProviders maps locale names to their All() functions.
 var localeProviders = map[string]func() []port.Detector{
+	"au":     au.All,
 	"common": common.All,
-	"us":     us.All,
-	"nl":     nl.All,
-	"eu":     eu.All,
-	"gb":     gb.All,
-	"kr":     kr.All,
 	"de":     de.All,
+	"eu":     eu.All,
 	"fr":     fr.All,
+	"gb":     gb.All,
 	"jp":     jp.All,
+	"kr":     kr.All,
+	"nl":     nl.All,
+	"us":     us.All,
 }
 
 // AllDetectors returns every registered PII detector across all locales.

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -59,7 +59,7 @@ func TestDetectorsForLocaleUnknown(t *testing.T) {
 
 func TestLocales(t *testing.T) {
 	locales := Locales()
-	expected := []string{"common", "de", "eu", "fr", "gb", "jp", "kr", "nl", "us"}
+	expected := []string{"au", "common", "de", "eu", "fr", "gb", "jp", "kr", "nl", "us"}
 	if len(locales) != len(expected) {
 		t.Fatalf("Locales() = %v, want %v", locales, expected)
 	}


### PR DESCRIPTION
## Summary
- Add `adapter/detector/au/` package with five PII detectors for Australia: TFN (Tax File Number), Medicare card number, ABN (Australian Business Number), phone numbers (mobile + landline), and postcodes
- Each detector includes checksum/format validation following official algorithms (weighted mod-11 for TFN, mod-10 for Medicare, mod-89 for ABN)
- Register the `au` locale in `adapter/registry/registry.go`
- Comprehensive test coverage in `au_test.go` with valid/invalid cases for every detector

Closes #19

## Test plan
- [x] `go test ./adapter/detector/au/` — all 6 tests pass
- [x] `go test ./adapter/registry/` — registry tests pass with `au` locale included
- [x] `go vet ./adapter/detector/au/ ./adapter/registry/` — no issues
- [x] All existing locale tests remain passing