### PR TITLE
feat: add Canada PII detectors (SIN, phone, postal code, passport)

### DIFF
--- a/adapter/detector/ca/all.go
+++ b/adapter/detector/ca/all.go
@@ -1,0 +1,13 @@
+package ca
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all Canada locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewSINDetector(),
+		NewPhoneDetector(),
+		NewPostalCodeDetector(),
+		NewPassportDetector(),
+	}
+}

--- a/adapter/detector/ca/ca_test.go
+++ b/adapter/detector/ca/ca_test.go
@@ -1,0 +1,196 @@
+package ca
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*SINDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*PostalCodeDetector)(nil)
+	_ port.Detector = (*PassportDetector)(nil)
+)
+
+func TestSINDetector(t *testing.T) {
+	d := NewSINDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"SIN: 046 454 286", 1, "valid SIN with spaces"},
+		{"SIN: 046-454-286", 1, "valid SIN with dashes"},
+		{"046454286", 1, "valid SIN no separators"},
+		{"000 000 000", 0, "all zeros invalid"},
+		{"123 456 789", 0, "fails Luhn check"},
+		{"12 345 678", 0, "too few digits in first group"},
+		{"no sin here", 0, "no SIN"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "ca" {
+				t.Errorf("expected locale 'ca', got %q", m.Locale)
+			}
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.85 {
+				t.Errorf("expected confidence 0.85, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestSINLuhn(t *testing.T) {
+	tests := []struct {
+		digits string
+		valid  bool
+	}{
+		{"046454286", true},
+		{"123456789", false},
+		{"000000000", false},
+	}
+	for _, tt := range tests {
+		if got := luhnValid(tt.digits); got != tt.valid {
+			t.Errorf("luhnValid(%q) = %v, want %v", tt.digits, got, tt.valid)
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Call (416) 555-1234", 1, "Toronto area code with parens"},
+		{"+1-604-555-1234", 1, "Vancouver with +1 prefix"},
+		{"514.555.1234", 1, "Montreal dot-separated"},
+		{"9055551234", 1, "Hamilton no separators"},
+		{"1-867-555-1234", 1, "Northern territories"},
+		{"(555) 123-4567", 0, "non-Canadian area code 555"},
+		{"(212) 555-1234", 0, "US area code 212"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "ca" {
+				t.Errorf("expected locale 'ca', got %q", m.Locale)
+			}
+			if m.Confidence != 0.80 {
+				t.Errorf("expected confidence 0.80, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPostalCodeDetector(t *testing.T) {
+	d := NewPostalCodeDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Postal: K1A 0B1", 1, "Ottawa with space"},
+		{"V6B3K9", 1, "Vancouver no space"},
+		{"M5V 2T6", 1, "Toronto"},
+		{"D1A 0B1", 0, "starts with D (invalid)"},
+		{"F1A 0B1", 0, "starts with F (invalid)"},
+		{"W1A 0B1", 0, "starts with W (invalid)"},
+		{"Z1A 0B1", 0, "starts with Z (invalid)"},
+		{"no postal here", 0, "no postal code"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "ca" {
+				t.Errorf("expected locale 'ca', got %q", m.Locale)
+			}
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+			if m.Confidence != 0.90 {
+				t.Errorf("expected confidence 0.90, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestPassportDetector(t *testing.T) {
+	d := NewPassportDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"Passport: AB123456", 1, "valid Canadian passport"},
+		{"GK987654", 1, "another valid passport"},
+		{"A1234567", 0, "only one letter"},
+		{"ABC12345", 0, "three letters"},
+		{"AB12345", 0, "only 5 digits"},
+		{"no passport", 0, "no passport"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "ca" {
+				t.Errorf("expected locale 'ca', got %q", m.Locale)
+			}
+			if m.Type != model.Passport {
+				t.Errorf("expected Passport type, got %v", m.Type)
+			}
+			if m.Confidence != 0.65 {
+				t.Errorf("expected confidence 0.65, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	detectors := All()
+	if len(detectors) != 4 {
+		t.Errorf("All() returned %d detectors, want 4", len(detectors))
+	}
+}

--- a/adapter/detector/ca/helpers.go
+++ b/adapter/detector/ca/helpers.go
@@ -1,0 +1,31 @@
+// Package ca provides PII detectors for Canada-specific patterns.
+package ca
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "ca"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/ca/passport.go
+++ b/adapter/detector/ca/passport.go
@@ -1,0 +1,24 @@
+package ca
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Canadian passport: 2 uppercase letters followed by 6 digits.
+var caPassportRe = regexp.MustCompile(`\b[A-Z]{2}\d{6}\b`)
+
+// PassportDetector detects Canadian passport numbers.
+type PassportDetector struct{}
+
+func NewPassportDetector() *PassportDetector { return &PassportDetector{} }
+
+func (d *PassportDetector) Name() string              { return "ca/passport" }
+func (d *PassportDetector) Locales() []string         { return []string{locale} }
+func (d *PassportDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Passport} }
+
+func (d *PassportDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(caPassportRe, text, model.Passport, 0.65, d.Name()), nil
+}

--- a/adapter/detector/ca/phone.go
+++ b/adapter/detector/ca/phone.go
@@ -1,0 +1,58 @@
+package ca
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// NANP phone: optional +1/1 prefix, area code, 7-digit subscriber number.
+var caPhoneRe = regexp.MustCompile(`(?:\+?1[\s.\-]?)?\(?([2-9]\d{2})\)?[\s.\-]?\d{3}[\s.\-]?\d{4}`)
+
+// canadianAreaCodes contains all Canadian area codes.
+var canadianAreaCodes = map[string]bool{
+	"204": true, "226": true, "236": true, "249": true, "250": true,
+	"289": true, "306": true, "343": true, "365": true, "387": true,
+	"403": true, "416": true, "418": true, "431": true, "437": true,
+	"438": true, "450": true, "506": true, "514": true, "519": true,
+	"548": true, "579": true, "581": true, "587": true, "604": true,
+	"613": true, "639": true, "647": true, "672": true, "705": true,
+	"709": true, "742": true, "778": true, "780": true, "782": true,
+	"807": true, "819": true, "825": true, "867": true, "873": true,
+	"902": true, "905": true,
+}
+
+// PhoneDetector detects Canadian phone numbers in NANP format.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "ca/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := caPhoneRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		areaCode := text[loc[2]:loc[3]]
+		if !canadianAreaCodes[areaCode] {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.Phone,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.80,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}

--- a/adapter/detector/ca/postal.go
+++ b/adapter/detector/ca/postal.go
@@ -1,0 +1,25 @@
+package ca
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Canadian postal code: letter-digit-letter space? digit-letter-digit.
+// First letter excludes D, F, I, O, Q, U, W, Z.
+var postalRe = regexp.MustCompile(`\b[ABCEGHJKLMNPRSTVXY]\d[A-Z]\s?\d[A-Z]\d\b`)
+
+// PostalCodeDetector detects Canadian postal codes.
+type PostalCodeDetector struct{}
+
+func NewPostalCodeDetector() *PostalCodeDetector { return &PostalCodeDetector{} }
+
+func (d *PostalCodeDetector) Name() string              { return "ca/postal_code" }
+func (d *PostalCodeDetector) Locales() []string         { return []string{locale} }
+func (d *PostalCodeDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *PostalCodeDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(postalRe, text, model.PostalCode, 0.90, d.Name()), nil
+}

--- a/adapter/detector/ca/sin.go
+++ b/adapter/detector/ca/sin.go
@@ -1,0 +1,76 @@
+package ca
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches 9-digit patterns: XXX XXX XXX or XXX-XXX-XXX or XXXXXXXXX.
+var sinRe = regexp.MustCompile(`\b(\d{3})[\s-]?(\d{3})[\s-]?(\d{3})\b`)
+
+// SINDetector detects Canadian Social Insurance Numbers.
+type SINDetector struct{}
+
+func NewSINDetector() *SINDetector { return &SINDetector{} }
+
+func (d *SINDetector) Name() string              { return "ca/sin" }
+func (d *SINDetector) Locales() []string         { return []string{locale} }
+func (d *SINDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *SINDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := sinRe.FindAllStringSubmatchIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		full := text[loc[0]:loc[1]]
+		g1 := text[loc[2]:loc[3]]
+		g2 := text[loc[4]:loc[5]]
+		g3 := text[loc[6]:loc[7]]
+
+		digits := g1 + g2 + g3
+		if !luhnValid(digits) {
+			continue
+		}
+
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      full,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.85,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// luhnValid checks whether digits satisfies the Luhn algorithm.
+func luhnValid(digits string) bool {
+	if len(digits) != 9 {
+		return false
+	}
+	// Reject all-zero SINs.
+	if digits == "000000000" {
+		return false
+	}
+
+	sum := 0
+	for i, ch := range digits {
+		n := int(ch - '0')
+		// Double every second digit (0-indexed: positions 1, 3, 5, 7).
+		if i%2 == 1 {
+			n *= 2
+			if n > 9 {
+				n -= 9
+			}
+		}
+		sum += n
+	}
+	return sum%10 == 0
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/taoq-ai/wuming/adapter/detector/au"
+	"github.com/taoq-ai/wuming/adapter/detector/ca"
 	"github.com/taoq-ai/wuming/adapter/detector/cn"
 	"github.com/taoq-ai/wuming/adapter/detector/common"
 	"github.com/taoq-ai/wuming/adapter/detector/de"
@@ -23,6 +24,7 @@ import (
 // localeProviders maps locale names to their All() functions.
 var localeProviders = map[string]func() []port.Detector{
 	"au":     au.All,
+	"ca":     ca.All,
 	"cn":     cn.All,
 	"common": common.All,
 	"de":     de.All,

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -59,7 +59,7 @@ func TestDetectorsForLocaleUnknown(t *testing.T) {
 
 func TestLocales(t *testing.T) {
 	locales := Locales()
-	expected := []string{"au", "cn", "common", "de", "eu", "fr", "gb", "in", "jp", "kr", "nl", "us"}
+	expected := []string{"au", "ca", "cn", "common", "de", "eu", "fr", "gb", "in", "jp", "kr", "nl", "us"}
 	if len(locales) != len(expected) {
 		t.Fatalf("Locales() = %v, want %v", locales, expected)
 	}


### PR DESCRIPTION
## Summary
- Add `adapter/detector/ca/` package with four Canada-specific PII detectors:
  - **SIN** (Social Insurance Number) — 9-digit Luhn-validated, confidence 0.85
  - **Phone** — NANP format filtered by Canadian area codes, confidence 0.80
  - **Postal code** — `A1A 1A1` format with valid first-letter constraint, confidence 0.90
  - **Passport** — 2 letters + 6 digits, confidence 0.65
- Register `ca` locale in `adapter/registry/registry.go`
- Comprehensive test coverage in `ca_test.go`

Closes #20

## Test plan
- [x] `go test ./adapter/detector/ca/...` passes
- [x] `go test ./adapter/registry/...` passes
- [x] `go vet ./...` clean
- [x] All existing tests still pass