### PR TITLE
feat: add Brazil PII detectors — CPF, CNPJ, phone, CEP, PIS, CNH

### DIFF
--- a/adapter/detector/br/all.go
+++ b/adapter/detector/br/all.go
@@ -1,0 +1,15 @@
+package br
+
+import "github.com/taoq-ai/wuming/domain/port"
+
+// All returns all BR locale PII detectors.
+func All() []port.Detector {
+	return []port.Detector{
+		NewCPFDetector(),
+		NewCNPJDetector(),
+		NewPhoneDetector(),
+		NewCEPDetector(),
+		NewPISDetector(),
+		NewCNHDetector(),
+	}
+}

--- a/adapter/detector/br/br_test.go
+++ b/adapter/detector/br/br_test.go
@@ -1,0 +1,223 @@
+package br
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+	"github.com/taoq-ai/wuming/domain/port"
+)
+
+var ctx = context.Background()
+
+// Verify all detectors implement port.Detector.
+var (
+	_ port.Detector = (*CPFDetector)(nil)
+	_ port.Detector = (*CNPJDetector)(nil)
+	_ port.Detector = (*PhoneDetector)(nil)
+	_ port.Detector = (*CEPDetector)(nil)
+	_ port.Detector = (*PISDetector)(nil)
+	_ port.Detector = (*CNHDetector)(nil)
+)
+
+func TestCPFDetector(t *testing.T) {
+	d := NewCPFDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"CPF: 529.982.247-25", 1, "valid formatted CPF"},
+		{"52998224725", 1, "valid unformatted CPF"},
+		{"111.111.111-11", 0, "all same digits invalid"},
+		{"000.000.000-00", 0, "all zeros invalid"},
+		{"529.982.247-00", 0, "wrong check digits"},
+		{"123.456.789-00", 0, "invalid check digits"},
+		{"no cpf here", 0, "no CPF"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "br" {
+				t.Errorf("expected locale 'br', got %q", m.Locale)
+			}
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+			if m.Confidence != 0.90 {
+				t.Errorf("expected confidence 0.90, got %f", m.Confidence)
+			}
+		}
+	}
+}
+
+func TestCNPJDetector(t *testing.T) {
+	d := NewCNPJDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"CNPJ: 11.222.333/0001-81", 1, "valid formatted CNPJ"},
+		{"11222333000181", 1, "valid unformatted CNPJ"},
+		{"11.111.111/1111-11", 0, "all same digits invalid"},
+		{"11.222.333/0001-00", 0, "wrong check digits"},
+		{"no cnpj here", 0, "no CNPJ"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Locale != "br" {
+				t.Errorf("expected locale 'br', got %q", m.Locale)
+			}
+			if m.Type != model.TaxID {
+				t.Errorf("expected TaxID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPhoneDetector(t *testing.T) {
+	d := NewPhoneDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"(11) 91234-5678", 1, "mobile with parens"},
+		{"+55 11 91234-5678", 1, "mobile with country code"},
+		{"(21) 2345-6789", 1, "landline with parens"},
+		{"+55 21 2345-6789", 1, "landline with country code"},
+		{"11 91234-5678", 1, "mobile without parens"},
+		{"no phone here", 0, "no phone"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.Phone {
+				t.Errorf("expected Phone type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestCEPDetector(t *testing.T) {
+	d := NewCEPDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"CEP: 01001-000", 1, "formatted CEP"},
+		{"01001000", 1, "unformatted CEP"},
+		{"1234567", 0, "too short"},
+		{"no cep here", 0, "no CEP"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.PostalCode {
+				t.Errorf("expected PostalCode type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestPISDetector(t *testing.T) {
+	d := NewPISDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"PIS: 123.45678.90-0", 1, "valid formatted PIS"},
+		{"12345678900", 1, "valid unformatted PIS"},
+		{"11111111111", 0, "all same digits invalid"},
+		{"no pis here", 0, "no PIS"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.NationalID {
+				t.Errorf("expected NationalID type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestCNHDetector(t *testing.T) {
+	d := NewCNHDetector()
+
+	tests := []struct {
+		input string
+		want  int
+		desc  string
+	}{
+		{"CNH: 50680454028", 1, "valid CNH"},
+		{"11111111111", 0, "all same digits invalid"},
+		{"12345678999", 0, "invalid check digits"},
+		{"no cnh here", 0, "no CNH"},
+	}
+
+	for _, tt := range tests {
+		matches, err := d.Detect(ctx, tt.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != tt.want {
+			t.Errorf("%s: Detect(%q) got %d matches, want %d", tt.desc, tt.input, len(matches), tt.want)
+		}
+		for _, m := range matches {
+			if m.Type != model.DriversLicense {
+				t.Errorf("expected DriversLicense type, got %v", m.Type)
+			}
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	detectors := All()
+	if len(detectors) != 6 {
+		t.Errorf("All() returned %d detectors, want 6", len(detectors))
+	}
+}

--- a/adapter/detector/br/cep.go
+++ b/adapter/detector/br/cep.go
@@ -1,0 +1,24 @@
+package br
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// CEP postal code: XXXXX-XXX or 8 digits.
+var cepRe = regexp.MustCompile(`\b\d{5}-\d{3}\b|\b\d{8}\b`)
+
+// CEPDetector detects Brazilian CEP postal codes.
+type CEPDetector struct{}
+
+func NewCEPDetector() *CEPDetector { return &CEPDetector{} }
+
+func (d *CEPDetector) Name() string              { return "br/cep" }
+func (d *CEPDetector) Locales() []string         { return []string{locale} }
+func (d *CEPDetector) PIITypes() []model.PIIType { return []model.PIIType{model.PostalCode} }
+
+func (d *CEPDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(cepRe, text, model.PostalCode, 0.70, d.Name()), nil
+}

--- a/adapter/detector/br/cnh.go
+++ b/adapter/detector/br/cnh.go
@@ -1,0 +1,81 @@
+package br
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// CNH: exactly 11 digits.
+var cnhRe = regexp.MustCompile(`\b\d{11}\b`)
+
+// CNHDetector detects Brazilian CNH (driver's license) numbers.
+type CNHDetector struct{}
+
+func NewCNHDetector() *CNHDetector { return &CNHDetector{} }
+
+func (d *CNHDetector) Name() string              { return "br/cnh" }
+func (d *CNHDetector) Locales() []string         { return []string{locale} }
+func (d *CNHDetector) PIITypes() []model.PIIType { return []model.PIIType{model.DriversLicense} }
+
+func (d *CNHDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := cnhRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		if !isValidCNH(raw) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.DriversLicense,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.75,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidCNH validates a CNH number using the double check digit algorithm.
+func isValidCNH(digits string) bool {
+	if len(digits) != 11 || allSameDigit(digits) {
+		return false
+	}
+
+	d := make([]int, 11)
+	for i, c := range digits {
+		d[i] = int(c - '0')
+	}
+
+	// First check digit.
+	sum1 := 0
+	for i := 0; i < 9; i++ {
+		sum1 += d[i] * (9 - i)
+	}
+	rest1 := sum1 % 11
+	check1 := 0
+	if rest1 >= 2 {
+		check1 = 11 - rest1
+	}
+
+	// Second check digit.
+	sum2 := 0
+	for i := 0; i < 9; i++ {
+		sum2 += d[i] * (1 + i)
+	}
+	rest2 := sum2 % 11
+	check2 := 0
+	if rest2 >= 2 {
+		check2 = 11 - rest2
+	}
+
+	return d[9] == check1 && d[10] == check2
+}

--- a/adapter/detector/br/cnpj.go
+++ b/adapter/detector/br/cnpj.go
@@ -1,0 +1,89 @@
+package br
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches CNPJ in XX.XXX.XXX/XXXX-XX or 14-digit unformatted form.
+var cnpjRe = regexp.MustCompile(`\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b|\b\d{14}\b`)
+
+// CNPJDetector detects Brazilian CNPJ numbers.
+type CNPJDetector struct{}
+
+func NewCNPJDetector() *CNPJDetector { return &CNPJDetector{} }
+
+func (d *CNPJDetector) Name() string              { return "br/cnpj" }
+func (d *CNPJDetector) Locales() []string         { return []string{locale} }
+func (d *CNPJDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *CNPJDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := cnpjRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) != 14 {
+			continue
+		}
+		if !isValidCNPJ(digits) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidCNPJ validates a CNPJ using the mod-11 algorithm with standard weights.
+func isValidCNPJ(digits string) bool {
+	if allSameDigit(digits) {
+		return false
+	}
+
+	d := make([]int, 14)
+	for i, c := range digits {
+		d[i] = int(c - '0')
+	}
+
+	// First check digit: weights [5,4,3,2,9,8,7,6,5,4,3,2].
+	w1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	sum := 0
+	for i := 0; i < 12; i++ {
+		sum += d[i] * w1[i]
+	}
+	rem := sum % 11
+	check1 := 0
+	if rem >= 2 {
+		check1 = 11 - rem
+	}
+	if d[12] != check1 {
+		return false
+	}
+
+	// Second check digit: weights [6,5,4,3,2,9,8,7,6,5,4,3,2].
+	w2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	sum = 0
+	for i := 0; i < 13; i++ {
+		sum += d[i] * w2[i]
+	}
+	rem = sum % 11
+	check2 := 0
+	if rem >= 2 {
+		check2 = 11 - rem
+	}
+	return d[13] == check2
+}

--- a/adapter/detector/br/cpf.go
+++ b/adapter/detector/br/cpf.go
@@ -1,0 +1,112 @@
+package br
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Matches CPF in XXX.XXX.XXX-XX or 11-digit unformatted form.
+var cpfRe = regexp.MustCompile(`\b(\d{3})\.(\d{3})\.(\d{3})-(\d{2})\b|\b(\d{11})\b`)
+
+// CPFDetector detects Brazilian CPF numbers.
+type CPFDetector struct{}
+
+func NewCPFDetector() *CPFDetector { return &CPFDetector{} }
+
+func (d *CPFDetector) Name() string              { return "br/cpf" }
+func (d *CPFDetector) Locales() []string         { return []string{locale} }
+func (d *CPFDetector) PIITypes() []model.PIIType { return []model.PIIType{model.TaxID} }
+
+func (d *CPFDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := cpfRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) != 11 {
+			continue
+		}
+		if !isValidCPF(digits) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.TaxID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.90,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidCPF validates a CPF using the mod-11 double check digit algorithm.
+func isValidCPF(digits string) bool {
+	// Reject all-same-digit sequences (e.g. 111.111.111-11).
+	if allSameDigit(digits) {
+		return false
+	}
+
+	d := make([]int, 11)
+	for i, c := range digits {
+		d[i] = int(c - '0')
+	}
+
+	// First check digit.
+	sum := 0
+	for i := 0; i < 9; i++ {
+		sum += d[i] * (10 - i)
+	}
+	rem := sum % 11
+	check1 := 0
+	if rem >= 2 {
+		check1 = 11 - rem
+	}
+	if d[9] != check1 {
+		return false
+	}
+
+	// Second check digit.
+	sum = 0
+	for i := 0; i < 10; i++ {
+		sum += d[i] * (11 - i)
+	}
+	rem = sum % 11
+	check2 := 0
+	if rem >= 2 {
+		check2 = 11 - rem
+	}
+	return d[10] == check2
+}
+
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+func allSameDigit(s string) bool {
+	if len(s) == 0 {
+		return true
+	}
+	first := s[0]
+	for i := 1; i < len(s); i++ {
+		if s[i] != first {
+			return false
+		}
+	}
+	return true
+}

--- a/adapter/detector/br/helpers.go
+++ b/adapter/detector/br/helpers.go
@@ -1,0 +1,31 @@
+// Package br provides PII detectors for Brazil-specific patterns.
+package br
+
+import (
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+const locale = "br"
+
+// findAll returns all non-overlapping matches of re in text.
+func findAll(re *regexp.Regexp, text string, piiType model.PIIType, confidence float64, detector string) []model.Match {
+	locs := re.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+	matches := make([]model.Match, 0, len(locs))
+	for _, loc := range locs {
+		matches = append(matches, model.Match{
+			Type:       piiType,
+			Value:      text[loc[0]:loc[1]],
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: confidence,
+			Locale:     locale,
+			Detector:   detector,
+		})
+	}
+	return matches
+}

--- a/adapter/detector/br/phone.go
+++ b/adapter/detector/br/phone.go
@@ -1,0 +1,29 @@
+package br
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Brazilian phone patterns:
+// Mobile:   (XX) 9XXXX-XXXX, +55 XX 9XXXX-XXXX, +55XX9XXXXXXXX
+// Landline: (XX) XXXX-XXXX,  +55 XX XXXX-XXXX,  +55XXXXXXXXXX
+var brPhoneRe = regexp.MustCompile(
+	`(?:\+55[\s\-]?)?\(?[1-9]\d\)?[\s\-]?9\d{4}[\s\-]?\d{4}` + // mobile
+		`|(?:\+55[\s\-]?)?\(?[1-9]\d\)?[\s\-]?[2-5]\d{3}[\s\-]?\d{4}`, // landline
+)
+
+// PhoneDetector detects Brazilian phone numbers.
+type PhoneDetector struct{}
+
+func NewPhoneDetector() *PhoneDetector { return &PhoneDetector{} }
+
+func (d *PhoneDetector) Name() string              { return "br/phone" }
+func (d *PhoneDetector) Locales() []string         { return []string{locale} }
+func (d *PhoneDetector) PIITypes() []model.PIIType { return []model.PIIType{model.Phone} }
+
+func (d *PhoneDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	return findAll(brPhoneRe, text, model.Phone, 0.85, d.Name()), nil
+}

--- a/adapter/detector/br/pis.go
+++ b/adapter/detector/br/pis.go
@@ -1,0 +1,73 @@
+package br
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// PIS/PASEP: XXX.XXXXX.XX-X or 11 digits.
+var pisRe = regexp.MustCompile(`\b\d{3}\.\d{5}\.\d{2}-\d\b|\b\d{11}\b`)
+
+// PISDetector detects Brazilian PIS/PASEP numbers.
+type PISDetector struct{}
+
+func NewPISDetector() *PISDetector { return &PISDetector{} }
+
+func (d *PISDetector) Name() string              { return "br/pis" }
+func (d *PISDetector) Locales() []string         { return []string{locale} }
+func (d *PISDetector) PIITypes() []model.PIIType { return []model.PIIType{model.NationalID} }
+
+func (d *PISDetector) Detect(_ context.Context, text string) ([]model.Match, error) {
+	results := pisRe.FindAllStringIndex(text, -1)
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	var matches []model.Match
+	for _, loc := range results {
+		raw := text[loc[0]:loc[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) != 11 {
+			continue
+		}
+		if !isValidPIS(digits) {
+			continue
+		}
+		matches = append(matches, model.Match{
+			Type:       model.NationalID,
+			Value:      raw,
+			Start:      loc[0],
+			End:        loc[1],
+			Confidence: 0.80,
+			Locale:     locale,
+			Detector:   d.Name(),
+		})
+	}
+	return matches, nil
+}
+
+// isValidPIS validates a PIS/PASEP number using mod-11 with weights [3,2,9,8,7,6,5,4,3,2].
+func isValidPIS(digits string) bool {
+	if allSameDigit(digits) {
+		return false
+	}
+
+	weights := []int{3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	d := make([]int, 11)
+	for i, c := range digits {
+		d[i] = int(c - '0')
+	}
+
+	sum := 0
+	for i := 0; i < 10; i++ {
+		sum += d[i] * weights[i]
+	}
+	rem := sum % 11
+	check := 0
+	if rem >= 2 {
+		check = 11 - rem
+	}
+	return d[10] == check
+}

--- a/adapter/registry/registry.go
+++ b/adapter/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/taoq-ai/wuming/adapter/detector/au"
+	"github.com/taoq-ai/wuming/adapter/detector/br"
 	"github.com/taoq-ai/wuming/adapter/detector/ca"
 	"github.com/taoq-ai/wuming/adapter/detector/cn"
 	"github.com/taoq-ai/wuming/adapter/detector/common"
@@ -24,6 +25,7 @@ import (
 // localeProviders maps locale names to their All() functions.
 var localeProviders = map[string]func() []port.Detector{
 	"au":     au.All,
+	"br":     br.All,
 	"ca":     ca.All,
 	"cn":     cn.All,
 	"common": common.All,

--- a/adapter/registry/registry_test.go
+++ b/adapter/registry/registry_test.go
@@ -59,7 +59,7 @@ func TestDetectorsForLocaleUnknown(t *testing.T) {
 
 func TestLocales(t *testing.T) {
 	locales := Locales()
-	expected := []string{"au", "ca", "cn", "common", "de", "eu", "fr", "gb", "in", "jp", "kr", "nl", "us"}
+	expected := []string{"au", "br", "ca", "cn", "common", "de", "eu", "fr", "gb", "in", "jp", "kr", "nl", "us"}
 	if len(locales) != len(expected) {
 		t.Fatalf("Locales() = %v, want %v", locales, expected)
 	}


### PR DESCRIPTION
## Summary
- Add `adapter/detector/br/` package with 6 Brazil-specific PII detectors: CPF, CNPJ, phone, CEP, PIS/PASEP, and CNH
- CPF and CNPJ use mod-11 check digit validation (confidence 0.90); PIS uses mod-11 with standard weights (0.80); CNH uses double check digit validation (0.75); phone uses regex for mobile/landline patterns (0.85); CEP uses regex for postal codes (0.70)
- Register `br` locale in `adapter/registry/registry.go`
- Comprehensive test coverage in `br_test.go` including interface compliance checks, valid/invalid inputs, and type/locale assertions

Closes #14

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 15 packages)
- [x] Interface compliance verified for all 6 detectors
- [x] Valid CPF/CNPJ/PIS/CNH numbers pass check digit validation
- [x] Invalid and all-same-digit inputs are correctly rejected
- [x] Phone regex matches mobile and landline formats with/without country code
- [x] CEP matches formatted and unformatted postal codes