### PR TITLE
ci: add CD pipeline, coverage, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report a bug in wuming
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the information below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or steps to reproduce the issue.
+      placeholder: |
+        ```go
+        package main
+
+        import "github.com/taoq-ai/wuming"
+
+        func main() {
+            // ...
+        }
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Output of `go version`.
+      placeholder: "go1.23.0 linux/amd64"
+    validations:
+      required: true
+
+  - type: input
+    id: wuming-version
+    attributes:
+      label: Wuming version
+      description: The version of wuming you are using.
+      placeholder: "v0.8.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information that might be helpful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement for wuming
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve? Is it related to a frustration?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you would like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you have considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, code examples, or screenshots.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+<!-- List the key changes -->
+
+-
+
+## Checklist
+
+- [ ] Code compiles without errors (`go build ./...`)
+- [ ] All tests pass (`go test -race ./...`)
+- [ ] Linter passes (`golangci-lint run ./...`)
+- [ ] New code has test coverage
+- [ ] Documentation updated (if applicable)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+## Related Issues
+
+<!-- Link related issues, e.g. Closes #123 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,16 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - run: go build ./...
-      - run: go test -race -cover ./...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
       - run: go vet ./...
+      - name: Upload coverage to Codecov
+        if: matrix.go-version == '1.23'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build verification
+        run: go build ./...
+
+      - name: Run full test suite
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Extract tag
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger pkg.go.dev indexing
+        run: GOPROXY=proxy.golang.org go list -m github.com/taoq-ai/wuming@${{ steps.tag.outputs.version }}
+
+      - name: Generate release notes summary
+        run: |
+          echo "## Release ${{ steps.tag.outputs.version }}" > release-notes.md
+          echo "" >> release-notes.md
+          echo "Published to [pkg.go.dev](https://pkg.go.dev/github.com/taoq-ai/wuming@${{ steps.tag.outputs.version }})" >> release-notes.md
+          echo "" >> release-notes.md
+          echo "### Install" >> release-notes.md
+          echo '```sh' >> release-notes.md
+          echo "go get github.com/taoq-ai/wuming@${{ steps.tag.outputs.version }}" >> release-notes.md
+          echo '```' >> release-notes.md
+          cat release-notes.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Enhanced CI workflow with code coverage upload to Codecov
- Added release workflow (`release.yml`) triggered on tag push (`v*`) for build verification, full test suite, pkg.go.dev indexing, and release notes generation
- Added GitHub issue templates (bug report, feature request) and PR template with checklist
- Docs workflow (`docs.yml`) already deploys MkDocs to GitHub Pages on push to main — verified, no changes needed

## Changes

- **`.github/workflows/ci.yml`** — replaced `go test -race -cover` with `-coverprofile=coverage.out -covermode=atomic`; added Codecov upload step (Go 1.23 matrix only)
- **`.github/workflows/release.yml`** — new workflow: build verification, race-condition tests, pkg.go.dev indexing via `GOPROXY=proxy.golang.org`, release notes summary
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — structured bug report with Go/wuming version fields
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — feature request with problem/solution/alternatives sections
- **`.github/PULL_REQUEST_TEMPLATE.md`** — PR checklist (build, test, lint, docs, conventional commits)

## Test plan

- [ ] Verify CI workflow runs with coverage on this PR
- [ ] Validate YAML syntax (done locally with Python yaml parser)
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template is pre-filled on new PRs

Closes #29