### PR TITLE
feat: add compliance presets (GDPR, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, Privacy Act)

### DIFF
--- a/adapter/preset/appi.go
+++ b/adapter/preset/appi.go
@@ -1,0 +1,13 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "appi",
+		Description: "Japan Act on the Protection of Personal Information — covers all personal data",
+		Locales:     []string{"common", "jp"},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/dpdp.go
+++ b/adapter/preset/dpdp.go
@@ -1,0 +1,13 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "dpdp",
+		Description: "India Digital Personal Data Protection Act — covers all personal data",
+		Locales:     []string{"common", "in"},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/gdpr.go
+++ b/adapter/preset/gdpr.go
@@ -1,0 +1,13 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "gdpr",
+		Description: "EU General Data Protection Regulation — covers all personal data across EU/EEA locales",
+		Locales:     []string{"common", "eu", "nl", "de", "fr", "gb"},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/hipaa.go
+++ b/adapter/preset/hipaa.go
@@ -1,0 +1,20 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "hipaa",
+		Description: "US Health Insurance Portability and Accountability Act — protected health information",
+		Locales:     []string{"common", "us"},
+		PIITypes: []model.PIIType{
+			model.NationalID,
+			model.HealthID,
+			model.Phone,
+			model.Email,
+			model.PostalCode,
+			model.DateOfBirth,
+		},
+		MinSeverity: model.Medium,
+	})
+}

--- a/adapter/preset/lgpd.go
+++ b/adapter/preset/lgpd.go
@@ -1,0 +1,13 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "lgpd",
+		Description: "Brazil Lei Geral de Proteção de Dados — covers all personal data",
+		Locales:     []string{"common", "br"},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/pci_dss.go
+++ b/adapter/preset/pci_dss.go
@@ -1,0 +1,15 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "pci-dss",
+		Description: "Payment Card Industry Data Security Standard — credit card data protection",
+		Locales:     []string{"common"},
+		PIITypes: []model.PIIType{
+			model.CreditCard,
+		},
+		MinSeverity: model.Critical,
+	})
+}

--- a/adapter/preset/pipa.go
+++ b/adapter/preset/pipa.go
@@ -1,0 +1,16 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "pipa",
+		Description: "South Korea Personal Information Protection Act — identity and contact data",
+		Locales:     []string{"common", "kr"},
+		PIITypes: []model.PIIType{
+			model.NationalID,
+			model.Phone,
+		},
+		MinSeverity: model.Medium,
+	})
+}

--- a/adapter/preset/pipeda.go
+++ b/adapter/preset/pipeda.go
@@ -1,0 +1,18 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "pipeda",
+		Description: "Canada Personal Information Protection and Electronic Documents Act",
+		Locales:     []string{"common", "ca"},
+		PIITypes: []model.PIIType{
+			model.NationalID,
+			model.HealthID,
+			model.Phone,
+			model.Email,
+		},
+		MinSeverity: model.Medium,
+	})
+}

--- a/adapter/preset/pipl.go
+++ b/adapter/preset/pipl.go
@@ -1,0 +1,13 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "pipl",
+		Description: "China Personal Information Protection Law — covers all personal data",
+		Locales:     []string{"common", "cn"},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/preset.go
+++ b/adapter/preset/preset.go
@@ -1,0 +1,71 @@
+// Package preset provides compliance-oriented configurations for PII detection.
+// Each preset bundles the locales, PII types, and severity threshold appropriate
+// for a specific data-protection regulation (e.g. GDPR, HIPAA, PCI-DSS).
+package preset
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+// Preset describes a compliance-oriented PII detection configuration.
+type Preset struct {
+	Name        string
+	Description string
+	Locales     []string        // which locale detectors to include
+	PIITypes    []model.PIIType // which PII types to detect
+	MinSeverity model.Severity  // minimum severity threshold
+}
+
+// allPIITypes returns every defined PIIType for presets that cover all personal data.
+func allPIITypes() []model.PIIType {
+	return []model.PIIType{
+		model.Email,
+		model.Phone,
+		model.CreditCard,
+		model.IBAN,
+		model.IPAddress,
+		model.URL,
+		model.MACAddress,
+		model.NationalID,
+		model.TaxID,
+		model.Passport,
+		model.DriversLicense,
+		model.HealthID,
+		model.DateOfBirth,
+		model.Name,
+		model.Address,
+		model.PostalCode,
+		model.BankAccount,
+		model.SocialMedia,
+	}
+}
+
+// registry maps preset names (lowercase) to their definitions.
+var registry = map[string]Preset{}
+
+// register adds a preset to the internal registry.
+func register(p Preset) {
+	registry[p.Name] = p
+}
+
+// Get returns the preset with the given name, or an error if it does not exist.
+func Get(name string) (Preset, error) {
+	p, ok := registry[name]
+	if !ok {
+		return Preset{}, fmt.Errorf("preset: unknown preset %q", name)
+	}
+	return p, nil
+}
+
+// List returns a sorted list of all registered preset names.
+func List() []string {
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/adapter/preset/preset_test.go
+++ b/adapter/preset/preset_test.go
@@ -1,0 +1,160 @@
+package preset
+
+import (
+	"testing"
+
+	"github.com/taoq-ai/wuming/domain/model"
+)
+
+func TestListReturnsAllPresets(t *testing.T) {
+	names := List()
+	want := []string{
+		"appi", "dpdp", "gdpr", "hipaa", "lgpd",
+		"pci-dss", "pipa", "pipeda", "pipl", "privacy-act",
+	}
+	if len(names) != len(want) {
+		t.Fatalf("List() returned %d presets, want %d: %v", len(names), len(want), names)
+	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Errorf("List()[%d] = %q, want %q", i, name, want[i])
+		}
+	}
+}
+
+func TestGetKnownPreset(t *testing.T) {
+	for _, name := range List() {
+		p, err := Get(name)
+		if err != nil {
+			t.Errorf("Get(%q) returned error: %v", name, err)
+			continue
+		}
+		if p.Name != name {
+			t.Errorf("Get(%q).Name = %q", name, p.Name)
+		}
+		if len(p.Locales) == 0 {
+			t.Errorf("Get(%q).Locales is empty", name)
+		}
+		if len(p.PIITypes) == 0 {
+			t.Errorf("Get(%q).PIITypes is empty", name)
+		}
+		if p.MinSeverity < model.Low || p.MinSeverity > model.Critical {
+			t.Errorf("Get(%q).MinSeverity = %d, out of range", name, p.MinSeverity)
+		}
+	}
+}
+
+func TestGetUnknownPresetReturnsError(t *testing.T) {
+	_, err := Get("nonexistent")
+	if err == nil {
+		t.Error("Get(\"nonexistent\") should return an error")
+	}
+}
+
+func TestGDPRPreset(t *testing.T) {
+	p, _ := Get("gdpr")
+	assertLocales(t, p, []string{"common", "eu", "nl", "de", "fr", "gb"})
+	assertSeverity(t, p, model.Low)
+	// GDPR covers all PII types.
+	if len(p.PIITypes) != len(allPIITypes()) {
+		t.Errorf("gdpr: got %d PII types, want %d", len(p.PIITypes), len(allPIITypes()))
+	}
+}
+
+func TestHIPAAPreset(t *testing.T) {
+	p, _ := Get("hipaa")
+	assertLocales(t, p, []string{"common", "us"})
+	assertSeverity(t, p, model.Medium)
+	assertContainsPIIType(t, p, model.NationalID)
+	assertContainsPIIType(t, p, model.HealthID)
+	assertContainsPIIType(t, p, model.DateOfBirth)
+}
+
+func TestPCIDSSPreset(t *testing.T) {
+	p, _ := Get("pci-dss")
+	assertLocales(t, p, []string{"common"})
+	assertSeverity(t, p, model.Critical)
+	if len(p.PIITypes) != 1 || p.PIITypes[0] != model.CreditCard {
+		t.Errorf("pci-dss: PIITypes = %v, want [CreditCard]", p.PIITypes)
+	}
+}
+
+func TestLGPDPreset(t *testing.T) {
+	p, _ := Get("lgpd")
+	assertLocales(t, p, []string{"common", "br"})
+	assertSeverity(t, p, model.Low)
+}
+
+func TestAPPIPreset(t *testing.T) {
+	p, _ := Get("appi")
+	assertLocales(t, p, []string{"common", "jp"})
+	assertSeverity(t, p, model.Low)
+}
+
+func TestPIPLPreset(t *testing.T) {
+	p, _ := Get("pipl")
+	assertLocales(t, p, []string{"common", "cn"})
+	assertSeverity(t, p, model.Low)
+}
+
+func TestPIPAPreset(t *testing.T) {
+	p, _ := Get("pipa")
+	assertLocales(t, p, []string{"common", "kr"})
+	assertSeverity(t, p, model.Medium)
+	assertContainsPIIType(t, p, model.NationalID)
+	assertContainsPIIType(t, p, model.Phone)
+}
+
+func TestDPDPPreset(t *testing.T) {
+	p, _ := Get("dpdp")
+	assertLocales(t, p, []string{"common", "in"})
+	assertSeverity(t, p, model.Low)
+}
+
+func TestPIPEDAPreset(t *testing.T) {
+	p, _ := Get("pipeda")
+	assertLocales(t, p, []string{"common", "ca"})
+	assertSeverity(t, p, model.Medium)
+	assertContainsPIIType(t, p, model.NationalID)
+	assertContainsPIIType(t, p, model.HealthID)
+}
+
+func TestPrivacyActPreset(t *testing.T) {
+	p, _ := Get("privacy-act")
+	assertLocales(t, p, []string{"common", "au"})
+	assertSeverity(t, p, model.Medium)
+	assertContainsPIIType(t, p, model.TaxID)
+	assertContainsPIIType(t, p, model.HealthID)
+}
+
+// --- helpers ---
+
+func assertLocales(t *testing.T, p Preset, want []string) {
+	t.Helper()
+	if len(p.Locales) != len(want) {
+		t.Errorf("%s: got %d locales %v, want %v", p.Name, len(p.Locales), p.Locales, want)
+		return
+	}
+	for i, l := range p.Locales {
+		if l != want[i] {
+			t.Errorf("%s: locale[%d] = %q, want %q", p.Name, i, l, want[i])
+		}
+	}
+}
+
+func assertSeverity(t *testing.T, p Preset, want model.Severity) {
+	t.Helper()
+	if p.MinSeverity != want {
+		t.Errorf("%s: MinSeverity = %v, want %v", p.Name, p.MinSeverity, want)
+	}
+}
+
+func assertContainsPIIType(t *testing.T, p Preset, want model.PIIType) {
+	t.Helper()
+	for _, pt := range p.PIITypes {
+		if pt == want {
+			return
+		}
+	}
+	t.Errorf("%s: PIITypes %v does not contain %v", p.Name, p.PIITypes, want)
+}

--- a/adapter/preset/privacy_act.go
+++ b/adapter/preset/privacy_act.go
@@ -1,0 +1,18 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "privacy-act",
+		Description: "Australia Privacy Act — tax, health, and contact data",
+		Locales:     []string{"common", "au"},
+		PIITypes: []model.PIIType{
+			model.TaxID,
+			model.HealthID,
+			model.Phone,
+			model.Email,
+		},
+		MinSeverity: model.Medium,
+	})
+}

--- a/wuming.go
+++ b/wuming.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/taoq-ai/wuming/adapter/preset"
 	"github.com/taoq-ai/wuming/adapter/registry"
 	"github.com/taoq-ai/wuming/adapter/replacer"
 	"github.com/taoq-ai/wuming/domain/model"
@@ -84,6 +85,34 @@ func WithConcurrency(n int) Option {
 func WithConfidenceThreshold(f float64) Option {
 	return func(c *config) {
 		c.confidenceThreshold = f
+	}
+}
+
+// WithPreset configures the instance for a specific compliance regulation
+// (e.g. "gdpr", "hipaa", "pci-dss"). It sets the appropriate locales, PII
+// types, and detectors based on the preset definition. Returns an error-
+// capturing option: if the preset name is unknown the resulting Wuming will
+// be nil and New will panic. Callers should validate names with preset.Get
+// or preset.List beforehand if unsure.
+func WithPreset(name string) Option {
+	return func(c *config) {
+		p, err := preset.Get(name)
+		if err != nil {
+			panic(err)
+		}
+
+		// Collect detectors for each locale in the preset.
+		seen := make(map[string]bool)
+		for _, locale := range p.Locales {
+			if seen[locale] {
+				continue
+			}
+			seen[locale] = true
+			c.detectors = append(c.detectors, registry.DetectorsForLocale(locale)...)
+			c.locales = append(c.locales, locale)
+		}
+
+		c.piiTypes = append(c.piiTypes, p.PIITypes...)
 	}
 }
 

--- a/wuming_test.go
+++ b/wuming_test.go
@@ -118,6 +118,66 @@ func TestPackageLevelDetect(t *testing.T) {
 	}
 }
 
+func TestWithPresetGDPR(t *testing.T) {
+	w := New(WithPreset("gdpr"))
+	// GDPR should detect email (common locale).
+	text := "Email john@example.com"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MatchCount == 0 {
+		t.Error("WithPreset(\"gdpr\") should detect PII, but found no matches")
+	}
+}
+
+func TestWithPresetHIPAA(t *testing.T) {
+	w := New(WithPreset("hipaa"))
+	// HIPAA should detect SSN (us locale, NationalID type).
+	text := "SSN: 078-05-1120"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasNationalID := false
+	for _, m := range result.Matches {
+		if m.Type == model.NationalID {
+			hasNationalID = true
+		}
+	}
+	if !hasNationalID {
+		t.Error("WithPreset(\"hipaa\") should detect NationalID (SSN)")
+	}
+}
+
+func TestWithPresetPCIDSS(t *testing.T) {
+	w := New(WithPreset("pci-dss"))
+	// PCI-DSS should detect credit cards.
+	text := "Card: 4111 1111 1111 1111"
+	result, err := w.Process(context.Background(), text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasCreditCard := false
+	for _, m := range result.Matches {
+		if m.Type == model.CreditCard {
+			hasCreditCard = true
+		}
+	}
+	if !hasCreditCard {
+		t.Error("WithPreset(\"pci-dss\") should detect CreditCard")
+	}
+}
+
+func TestWithPresetUnknownPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("WithPreset(\"nonexistent\") should panic")
+		}
+	}()
+	New(WithPreset("nonexistent"))
+}
+
 func TestWithLocaleFilters(t *testing.T) {
 	w := New(WithLocale("nl"))
 	// BSN should be detected, SSN should not (US-specific).


### PR DESCRIPTION
## Summary

- Add `adapter/preset` package with 10 compliance-oriented PII detection presets: GDPR, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, and Privacy Act (Australia)
- Each preset bundles the appropriate locales, PII types, and minimum severity threshold for its regulation
- Add `WithPreset(name string) Option` to the public API in `wuming.go` for one-liner compliance configuration

## Test plan

- [x] `adapter/preset/preset_test.go` — tests `Get()`, `List()`, unknown preset error, and validates each preset's locales, PII types, and severity
- [x] `wuming_test.go` — tests `WithPreset` for GDPR (email detection), HIPAA (SSN detection), PCI-DSS (credit card detection), and unknown preset panic
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #21