### PR TITLE
docs: update README and docs for all 14 locales, presets, and zero-config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,25 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/taoq-ai/wuming)](https://goreportcard.com/report/github.com/taoq-ai/wuming)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/taoq-ai/wuming/actions/workflows/ci.yml/badge.svg)](https://github.com/taoq-ai/wuming/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-TBD-yellowgreen)](https://github.com/taoq-ai/wuming)
 
 ---
 
 ## Features
 
+- **Zero-config detection** — a single function call catches all PII globally, no setup required
+- **Global coverage** — 14 locales, 75+ detectors spanning every major region (Americas, Europe, Asia-Pacific)
+- **10 compliance presets** — preconfigured profiles for GDPR, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, and Privacy Act
+- **Locale-aware registry** — filter detectors with `WithLocale()` so only relevant patterns run
 - **Hexagonal architecture** — clean separation between domain logic, ports, and adapters
-- **Global coverage** — detectors for common patterns (email, credit card, IBAN) plus locale-specific PII (US SSN, Dutch BSN, UK NIN, German Steuer-ID, French NIR, EU VAT)
 - **Pluggable replacers** — redact, mask, hash, or bring your own replacement strategy
 - **Concurrent detection** — run multiple detectors in parallel with configurable concurrency
 - **Confidence scoring** — every match includes a confidence score; filter by threshold
 - **Zero dependencies** — pure Go standard library, no external modules
 
 ## Quick Start
+
+### Zero-Config (catches everything)
 
 ```go
 package main
@@ -43,15 +49,23 @@ func main() {
     }
     fmt.Println(redacted)
     // Output: SSN [NATIONAL_ID], email [EMAIL]
-
-    // Locale-specific — only Dutch + common detectors.
-    w := wuming.New(wuming.WithLocale("nl"))
-    result, err := w.Process(ctx, "BSN 123456782, call 06-12345678")
-    if err != nil {
-        log.Fatal(err)
-    }
-    fmt.Println(result.Redacted)
 }
+```
+
+### Compliance Preset
+
+```go
+// Configure for GDPR compliance — only EU/EEA locales and PII types.
+w := wuming.New(wuming.WithPreset("gdpr"))
+result, err := w.Process(ctx, "Steuer-ID 12345678911, email jan@example.de")
+```
+
+### Locale-Specific
+
+```go
+// Only Dutch + common detectors.
+w := wuming.New(wuming.WithLocale("nl"))
+result, err := w.Process(ctx, "BSN 123456782, call 06-12345678")
 ```
 
 ## Installation
@@ -73,6 +87,35 @@ Requires **Go 1.22** or later.
 | gb       | `adapter/detector/gb`            | NIN, NHS Number, UTR, Phone, Postcode                     |
 | de       | `adapter/detector/de`            | Steuer-ID, Sozialversicherungsnummer, Phone, PLZ, ID Card |
 | fr       | `adapter/detector/fr`            | NIR, NIF, Phone, Postal Code, ID Card                     |
+| br       | `adapter/detector/br`            | CPF, CNPJ, Phone, CEP, PIS/PASEP, CNH                    |
+| jp       | `adapter/detector/jp`            | My Number, Corporate Number, Phone, Postal Code, Passport |
+| in       | `adapter/detector/in`            | Aadhaar, PAN, Phone, PIN Code, Passport, GSTIN            |
+| cn       | `adapter/detector/cn`            | Resident ID, Phone, Postal Code, Passport, USCC           |
+| kr       | `adapter/detector/kr`            | RRN, Phone, Postal Code, Passport                         |
+| au       | `adapter/detector/au`            | TFN, Medicare, ABN, Phone, Postcode                       |
+| ca       | `adapter/detector/ca`            | SIN, Phone, Postal Code, Passport                         |
+
+## Compliance Presets
+
+Presets bundle the right locales and PII types for a specific regulation. Use them to get compliant detection without manual configuration.
+
+| Preset        | Regulation                                               | Locales                        |
+|---------------|----------------------------------------------------------|--------------------------------|
+| `gdpr`        | EU General Data Protection Regulation                    | common, eu, nl, de, fr, gb     |
+| `hipaa`       | US Health Insurance Portability and Accountability Act   | common, us                     |
+| `pci-dss`     | Payment Card Industry Data Security Standard             | common                         |
+| `lgpd`        | Brazil Lei Geral de Protecao de Dados                    | common, br                     |
+| `appi`        | Japan Act on the Protection of Personal Information      | common, jp                     |
+| `pipl`        | China Personal Information Protection Law                | common, cn                     |
+| `pipa`        | South Korea Personal Information Protection Act          | common, kr                     |
+| `dpdp`        | India Digital Personal Data Protection Act               | common, in                     |
+| `pipeda`      | Canada Personal Information Protection and Electronic Documents Act | common, ca          |
+| `privacy-act` | Australia Privacy Act                                    | common, au                     |
+
+```go
+w := wuming.New(wuming.WithPreset("gdpr"))
+result, err := w.Process(ctx, text)
+```
 
 ## Replacer Strategies
 
@@ -112,6 +155,8 @@ Wuming follows a hexagonal (ports & adapters) architecture:
 ├──────────┼──────────────────────────┤
 │ Adapters │  adapter/detector/{loc}  │
 │          │  adapter/replacer/       │
+│          │  adapter/preset/         │
+│          │  adapter/registry/       │
 └──────────┴──────────────────────────┘
 ```
 

--- a/docs/detectors/au.md
+++ b/docs/detectors/au.md
@@ -1,0 +1,79 @@
+# Australia Detectors
+
+Australia detectors cover PII patterns specific to the Australian context. They are activated when the `"au"` locale is configured.
+
+## TFN (Tax File Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `au/tfn` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Weighted checksum |
+
+Detects Australian Tax File Numbers. The TFN is a unique 8 or 9-digit number validated using a weighted checksum algorithm.
+
+**Examples:** `123 456 782`, `123456782`
+
+!!! warning "Regulatory Context"
+    TFN is regulated under the **Privacy Act 1988** and the Tax File Number Guidelines. Unauthorized recording or disclosure is prohibited. Severity: **High**.
+
+---
+
+## Medicare Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `au/medicare` |
+| PII Type | `HEALTH_ID` |
+| Confidence | 0.80 |
+| Validation | Check digit |
+
+Detects Australian Medicare card numbers (10 or 11 digits).
+
+**Examples:** `2123 45670 1`, `21234567`
+
+---
+
+## ABN (Australian Business Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `au/abn` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Weighted checksum |
+
+Detects Australian Business Numbers. The ABN is an 11-digit number with a weighted checksum.
+
+**Examples:** `51 824 753 556`, `51824753556`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `au/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Australian format |
+
+Detects Australian phone numbers in mobile and landline formats.
+
+**Examples:** `0412 345 678`, `+61 2 1234 5678`, `(02) 1234 5678`
+
+---
+
+## Postcode
+
+| Property | Value |
+|----------|-------|
+| Detector | `au/postcode` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Australian postcodes (4-digit numbers).
+
+**Examples:** `2000`, `3000`, `4000`

--- a/docs/detectors/br.md
+++ b/docs/detectors/br.md
@@ -1,0 +1,91 @@
+# Brazil Detectors
+
+Brazil detectors cover PII patterns specific to the Brazilian context. They are activated when the `"br"` locale is configured.
+
+## CPF (Cadastro de Pessoas Fisicas)
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/cpf` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Check digits |
+
+Detects Brazilian individual taxpayer registration numbers (CPF). The CPF is an 11-digit number with two check digits validated using a weighted modular arithmetic algorithm.
+
+**Examples:** `123.456.789-09`, `12345678909`
+
+---
+
+## CNPJ (Cadastro Nacional da Pessoa Juridica)
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/cnpj` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.90 |
+| Validation | Check digits |
+
+Detects Brazilian corporate taxpayer registration numbers (CNPJ). The CNPJ is a 14-digit number with two check digits.
+
+**Examples:** `11.222.333/0001-81`, `11222333000181`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Brazilian format |
+
+Detects Brazilian phone numbers in mobile and landline formats.
+
+**Examples:** `(11) 91234-5678`, `+55 11 91234-5678`
+
+---
+
+## CEP (Codigo de Enderecamento Postal)
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/cep` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Brazilian postal codes in the `NNNNN-NNN` format.
+
+**Examples:** `01001-000`, `12345-678`
+
+---
+
+## PIS/PASEP
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/pis` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.80 |
+| Validation | Check digit |
+
+Detects Brazilian social integration program numbers (PIS/PASEP), used for social security and employment purposes.
+
+**Examples:** `123.45678.90-1`
+
+---
+
+## CNH (Carteira Nacional de Habilitacao)
+
+| Property | Value |
+|----------|-------|
+| Detector | `br/cnh` |
+| PII Type | `DRIVERS_LICENSE` |
+| Confidence | 0.75 |
+| Validation | Pattern matching |
+
+Detects Brazilian driver's license numbers (CNH).
+
+**Examples:** `12345678901`

--- a/docs/detectors/ca.md
+++ b/docs/detectors/ca.md
@@ -1,0 +1,64 @@
+# Canada Detectors
+
+Canada detectors cover PII patterns specific to the Canadian context. They are activated when the `"ca"` locale is configured.
+
+## SIN (Social Insurance Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `ca/sin` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Luhn check digit |
+
+Detects Canadian Social Insurance Numbers. The SIN is a 9-digit number validated using the Luhn algorithm.
+
+**Examples:** `123 456 782`, `123-456-782`
+
+!!! warning "Regulatory Context"
+    SIN is regulated under **PIPEDA** and the Privacy Act. Collection is restricted to authorized purposes. Severity: **High**.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `ca/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | NANP format |
+
+Detects Canadian phone numbers following the North American Numbering Plan.
+
+**Examples:** `(416) 123-4567`, `+1 604 123 4567`, `416-123-4567`
+
+---
+
+## Postal Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `ca/postal_code` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Canadian format |
+
+Detects Canadian postal codes in the `A1A 1A1` format (alternating letter-digit-letter, space, digit-letter-digit).
+
+**Examples:** `K1A 0B1`, `M5V 2T6`
+
+---
+
+## Passport
+
+| Property | Value |
+|----------|-------|
+| Detector | `ca/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Canadian passport numbers.
+
+**Examples:** `AB123456`

--- a/docs/detectors/cn.md
+++ b/docs/detectors/cn.md
@@ -1,0 +1,79 @@
+# China Detectors
+
+China detectors cover PII patterns specific to the Chinese context. They are activated when the `"cn"` locale is configured.
+
+## Resident Identity Card Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `cn/resident_id` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Check digit (GB 11643) |
+
+Detects Chinese resident identity card numbers. The 18-digit number encodes region, birth date, sequence, and a check digit calculated per the GB 11643 standard.
+
+**Examples:** `110101199003077593`
+
+!!! warning "Regulatory Context"
+    Resident ID numbers are regulated under **PIPL** (Personal Information Protection Law). Severity: **Critical**.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `cn/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Chinese format |
+
+Detects Chinese phone numbers in mobile and landline formats.
+
+**Examples:** `13812345678`, `+86 138 1234 5678`
+
+---
+
+## Postal Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `cn/postal` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Chinese postal codes (6-digit numbers).
+
+**Examples:** `100000`, `200001`
+
+---
+
+## Passport
+
+| Property | Value |
+|----------|-------|
+| Detector | `cn/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Chinese passport numbers.
+
+**Examples:** `E12345678`, `G87654321`
+
+---
+
+## USCC (Unified Social Credit Code)
+
+| Property | Value |
+|----------|-------|
+| Detector | `cn/uscc` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Pattern matching |
+
+Detects Chinese Unified Social Credit Codes, which are 18-character alphanumeric identifiers assigned to organizations.
+
+**Examples:** `91110000MA001AA123`

--- a/docs/detectors/in.md
+++ b/docs/detectors/in.md
@@ -1,0 +1,94 @@
+# India Detectors
+
+India detectors cover PII patterns specific to the Indian context. They are activated when the `"in"` locale is configured.
+
+## Aadhaar
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/aadhaar` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Verhoeff checksum |
+
+Detects Indian Aadhaar numbers. Aadhaar is a 12-digit unique identity number issued by UIDAI, validated using the Verhoeff checksum algorithm.
+
+**Examples:** `2345 6789 0123`, `234567890123`
+
+!!! warning "Regulatory Context"
+    Aadhaar is regulated under the **Aadhaar Act, 2016** and the **DPDP Act**. Unauthorized collection or storage is prohibited. Severity: **Critical**.
+
+---
+
+## PAN (Permanent Account Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/pan` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Pattern matching |
+
+Detects Indian Permanent Account Numbers issued by the Income Tax Department. PAN follows the format `AAAAA9999A` (5 letters, 4 digits, 1 letter).
+
+**Examples:** `ABCDE1234F`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Indian format |
+
+Detects Indian phone numbers in mobile and landline formats.
+
+**Examples:** `+91 98765 43210`, `098765 43210`
+
+---
+
+## PIN Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/pin_code` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Indian postal PIN codes (6-digit numbers).
+
+**Examples:** `110001`, `400001`
+
+---
+
+## Passport
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Indian passport numbers.
+
+**Examples:** `A1234567`, `Z9876543`
+
+---
+
+## GSTIN
+
+| Property | Value |
+|----------|-------|
+| Detector | `in/gstin` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.85 |
+| Validation | Check digit |
+
+Detects Indian Goods and Services Tax Identification Numbers (GSTIN). GSTIN is a 15-character alphanumeric identifier.
+
+**Examples:** `22AAAAA0000A1Z5`

--- a/docs/detectors/jp.md
+++ b/docs/detectors/jp.md
@@ -1,0 +1,79 @@
+# Japan Detectors
+
+Japan detectors cover PII patterns specific to the Japanese context. They are activated when the `"jp"` locale is configured.
+
+## My Number (Individual Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `jp/my_number` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Check digit |
+
+Detects Japanese Individual Number (My Number) identifiers. The My Number is a 12-digit number assigned to residents, with check digit validation.
+
+**Examples:** `123456789012`
+
+!!! warning "Regulatory Context"
+    My Number is regulated under **APPI** and the My Number Act. Unauthorized use or collection is prohibited. Severity: **High**.
+
+---
+
+## Corporate Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `jp/corporate_number` |
+| PII Type | `TAX_ID` |
+| Confidence | 0.90 |
+| Validation | Check digit |
+
+Detects Japanese corporate numbers (13-digit identifiers assigned to corporations).
+
+**Examples:** `1234567890123`
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `jp/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Japanese format |
+
+Detects Japanese phone numbers in fixed-line and mobile formats.
+
+**Examples:** `03-1234-5678`, `090-1234-5678`, `+81 3 1234 5678`
+
+---
+
+## Postal Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `jp/postal` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Japanese postal codes in the `NNN-NNNN` format.
+
+**Examples:** `100-0001`, `160-0023`
+
+---
+
+## Passport
+
+| Property | Value |
+|----------|-------|
+| Detector | `jp/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Japanese passport numbers.
+
+**Examples:** `TK1234567`

--- a/docs/detectors/kr.md
+++ b/docs/detectors/kr.md
@@ -1,0 +1,64 @@
+# South Korea Detectors
+
+South Korea detectors cover PII patterns specific to the Korean context. They are activated when the `"kr"` locale is configured.
+
+## RRN (Resident Registration Number)
+
+| Property | Value |
+|----------|-------|
+| Detector | `kr/rrn` |
+| PII Type | `NATIONAL_ID` |
+| Confidence | 0.90 |
+| Validation | Check digit |
+
+Detects Korean Resident Registration Numbers. The RRN is a 13-digit number encoding birth date, gender, and a check digit.
+
+**Examples:** `901231-1234567`
+
+!!! warning "Regulatory Context"
+    RRN is regulated under **PIPA** (Personal Information Protection Act). Collection requires explicit consent. Severity: **Critical**.
+
+---
+
+## Phone Number
+
+| Property | Value |
+|----------|-------|
+| Detector | `kr/phone` |
+| PII Type | `PHONE` |
+| Confidence | 0.85 |
+| Validation | Korean format |
+
+Detects Korean phone numbers in mobile and landline formats.
+
+**Examples:** `010-1234-5678`, `+82 10 1234 5678`, `02-123-4567`
+
+---
+
+## Postal Code
+
+| Property | Value |
+|----------|-------|
+| Detector | `kr/postal` |
+| PII Type | `POSTAL_CODE` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Korean postal codes (5-digit numbers).
+
+**Examples:** `06236`, `12345`
+
+---
+
+## Passport
+
+| Property | Value |
+|----------|-------|
+| Detector | `kr/passport` |
+| PII Type | `PASSPORT` |
+| Confidence | 0.60 |
+| Validation | Regex |
+
+Detects Korean passport numbers.
+
+**Examples:** `M12345678`, `R98765432`

--- a/docs/detectors/overview.md
+++ b/docs/detectors/overview.md
@@ -41,6 +41,41 @@ Detectors are the core building blocks of wuming. Each detector scans input text
 | FR | ID Card | NATIONAL_ID | 0.65 | Old (12-digit) + new (9-char) |
 | FR | Phone | PHONE | 0.85 | French format |
 | FR | Postal Code | POSTAL_CODE | 0.60 | Department prefix validation |
+| BR | CPF | NATIONAL_ID | 0.90 | Check digits |
+| BR | CNPJ | TAX_ID | 0.90 | Check digits |
+| BR | Phone | PHONE | 0.85 | Brazilian format |
+| BR | CEP | POSTAL_CODE | 0.60 | Regex |
+| BR | PIS/PASEP | NATIONAL_ID | 0.80 | Check digit |
+| BR | CNH | DRIVERS_LICENSE | 0.75 | Pattern matching |
+| JP | My Number | NATIONAL_ID | 0.90 | Check digit |
+| JP | Corporate Number | TAX_ID | 0.90 | Check digit |
+| JP | Phone | PHONE | 0.85 | Japanese format |
+| JP | Postal Code | POSTAL_CODE | 0.60 | Regex |
+| JP | Passport | PASSPORT | 0.60 | Regex |
+| IN | Aadhaar | NATIONAL_ID | 0.90 | Verhoeff checksum |
+| IN | PAN | TAX_ID | 0.85 | Pattern matching |
+| IN | Phone | PHONE | 0.85 | Indian format |
+| IN | PIN Code | POSTAL_CODE | 0.60 | Regex |
+| IN | Passport | PASSPORT | 0.60 | Regex |
+| IN | GSTIN | TAX_ID | 0.85 | Check digit |
+| CN | Resident ID | NATIONAL_ID | 0.90 | Check digit (GB 11643) |
+| CN | Phone | PHONE | 0.85 | Chinese format |
+| CN | Postal Code | POSTAL_CODE | 0.60 | Regex |
+| CN | Passport | PASSPORT | 0.60 | Regex |
+| CN | USCC | TAX_ID | 0.85 | Pattern matching |
+| KR | RRN | NATIONAL_ID | 0.90 | Check digit |
+| KR | Phone | PHONE | 0.85 | Korean format |
+| KR | Postal Code | POSTAL_CODE | 0.60 | Regex |
+| KR | Passport | PASSPORT | 0.60 | Regex |
+| AU | TFN | TAX_ID | 0.85 | Weighted checksum |
+| AU | Medicare | HEALTH_ID | 0.80 | Check digit |
+| AU | ABN | TAX_ID | 0.85 | Weighted checksum |
+| AU | Phone | PHONE | 0.85 | Australian format |
+| AU | Postcode | POSTAL_CODE | 0.60 | Regex |
+| CA | SIN | NATIONAL_ID | 0.90 | Luhn check digit |
+| CA | Phone | PHONE | 0.85 | NANP format |
+| CA | Postal Code | POSTAL_CODE | 0.60 | Canadian format |
+| CA | Passport | PASSPORT | 0.60 | Regex |
 
 ## The Detector Interface
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,6 +28,26 @@ result, err := wuming.Process(ctx, text)
 // result.Original, result.Redacted, result.Matches, result.MatchCount
 ```
 
+## Compliance Preset
+
+Use a preset to configure detection for a specific regulation. The preset automatically selects the right locales and PII types:
+
+```go
+// GDPR — EU/EEA personal data
+w := wuming.New(wuming.WithPreset("gdpr"))
+result, err := w.Process(ctx, "Steuer-ID 12345678911, email jan@example.de")
+
+// HIPAA — US protected health information
+w = wuming.New(wuming.WithPreset("hipaa"))
+result, err = w.Process(ctx, "SSN 123-45-6789, Medicare 1EG4-TE5-MK72")
+
+// PCI-DSS — credit card data only
+w = wuming.New(wuming.WithPreset("pci-dss"))
+result, err = w.Process(ctx, "Card: 4111-1111-1111-1111")
+```
+
+See [Compliance Presets](../presets.md) for all 10 available presets.
+
 ## Custom Instance
 
 Create a configured instance for more control:

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,0 +1,112 @@
+# Compliance Presets
+
+Presets bundle the right locales, PII types, and severity thresholds for a specific data-protection regulation. Instead of manually configuring which detectors and PII types to use, you can select a preset and wuming handles the rest.
+
+## Usage
+
+```go
+w := wuming.New(wuming.WithPreset("gdpr"))
+result, err := w.Process(ctx, text)
+```
+
+You can list all available presets programmatically:
+
+```go
+import "github.com/taoq-ai/wuming/adapter/preset"
+
+names := preset.List()
+// ["appi", "dpdp", "gdpr", "hipaa", "lgpd", "pci-dss", "pipa", "pipeda", "pipl", "privacy-act"]
+```
+
+## Available Presets
+
+### GDPR
+
+**EU General Data Protection Regulation** -- covers all personal data across EU/EEA locales.
+
+- **Locales**: common, eu, nl, de, fr, gb
+- **PII types**: all
+- **Min severity**: Low
+
+### HIPAA
+
+**US Health Insurance Portability and Accountability Act** -- protected health information.
+
+- **Locales**: common, us
+- **PII types**: National ID, Health ID, Phone, Email, Postal Code, Date of Birth
+- **Min severity**: Medium
+
+### PCI-DSS
+
+**Payment Card Industry Data Security Standard** -- credit card data protection.
+
+- **Locales**: common
+- **PII types**: Credit Card
+- **Min severity**: Critical
+
+### LGPD
+
+**Brazil Lei Geral de Protecao de Dados** -- covers all personal data.
+
+- **Locales**: common, br
+- **PII types**: all
+- **Min severity**: Low
+
+### APPI
+
+**Japan Act on the Protection of Personal Information** -- covers all personal data.
+
+- **Locales**: common, jp
+- **PII types**: all
+- **Min severity**: Low
+
+### PIPL
+
+**China Personal Information Protection Law** -- covers all personal data.
+
+- **Locales**: common, cn
+- **PII types**: all
+- **Min severity**: Low
+
+### PIPA
+
+**South Korea Personal Information Protection Act** -- identity and contact data.
+
+- **Locales**: common, kr
+- **PII types**: National ID, Phone
+- **Min severity**: Medium
+
+### DPDP
+
+**India Digital Personal Data Protection Act** -- covers all personal data.
+
+- **Locales**: common, in
+- **PII types**: all
+- **Min severity**: Low
+
+### PIPEDA
+
+**Canada Personal Information Protection and Electronic Documents Act**.
+
+- **Locales**: common, ca
+- **PII types**: National ID, Health ID, Phone, Email
+- **Min severity**: Medium
+
+### Privacy Act
+
+**Australia Privacy Act** -- tax, health, and contact data.
+
+- **Locales**: common, au
+- **PII types**: Tax ID, Health ID, Phone, Email
+- **Min severity**: Medium
+
+## How Presets Work
+
+When you call `wuming.WithPreset("gdpr")`, wuming:
+
+1. Looks up the preset definition in the internal registry
+2. Loads detectors for each locale listed in the preset
+3. Filters results to only the PII types the regulation requires
+4. Common (global) detectors are always included automatically
+
+Presets are defined in `adapter/preset/` with one file per regulation. You can inspect or extend them by adding new files that call `register()` in an `init()` function.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,14 @@ nav:
     - United Kingdom: detectors/gb.md
     - Germany: detectors/de.md
     - France: detectors/fr.md
+    - Brazil: detectors/br.md
+    - Japan: detectors/jp.md
+    - India: detectors/in.md
+    - China: detectors/cn.md
+    - South Korea: detectors/kr.md
+    - Australia: detectors/au.md
+    - Canada: detectors/ca.md
+  - Compliance Presets: presets.md
   - Replacers: replacers.md
   - Contributing: contributing.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Updated README.md with all 14 supported locales (was 7), 10 compliance presets, zero-config detection, and registry features
- Added coverage badge placeholder to README badge line
- Updated architecture diagram to include preset and registry adapter packages
- Added new Quick Start sections for compliance presets and locale-specific usage
- Created `docs/presets.md` with full documentation for all 10 compliance presets (GDPR, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, Privacy Act)
- Added 7 new locale detector doc pages: Brazil, Japan, India, China, South Korea, Australia, Canada
- Updated `docs/detectors/overview.md` with all 75+ detectors across 14 locales
- Updated `docs/getting-started/quickstart.md` with compliance preset examples
- Updated `mkdocs.yml` nav to include all new locale pages and presets page

## Test plan

- [x] `go build ./...` passes
- [ ] Review rendered README on GitHub for formatting
- [ ] Review MkDocs site locally with `mkdocs serve` if available