### PR TITLE
feat: add EU AI Act compliance preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - **Zero-config detection** — a single function call catches all PII globally, no setup required
 - **Global coverage** — 14 locales, 75+ detectors spanning every major region (Americas, Europe, Asia-Pacific)
-- **10 compliance presets** — preconfigured profiles for GDPR, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, and Privacy Act
+- **11 compliance presets** — preconfigured profiles for GDPR, AI Act, HIPAA, PCI-DSS, LGPD, APPI, PIPL, PIPA, DPDP, PIPEDA, and Privacy Act
 - **Locale-aware registry** — filter detectors with `WithLocale()` so only relevant patterns run
 - **Hexagonal architecture** — clean separation between domain logic, ports, and adapters
 - **Pluggable replacers** — redact, mask, hash, or bring your own replacement strategy
@@ -102,6 +102,7 @@ Presets bundle the right locales and PII types for a specific regulation. Use th
 | Preset        | Regulation                                               | Locales                        |
 |---------------|----------------------------------------------------------|--------------------------------|
 | `gdpr`        | EU General Data Protection Regulation                    | common, eu, nl, de, fr, gb     |
+| `ai-act`      | EU AI Act (Articles 10, 15)                              | all 14 locales                 |
 | `hipaa`       | US Health Insurance Portability and Accountability Act   | common, us                     |
 | `pci-dss`     | Payment Card Industry Data Security Standard             | common                         |
 | `lgpd`        | Brazil Lei Geral de Protecao de Dados                    | common, br                     |

--- a/adapter/preset/ai_act.go
+++ b/adapter/preset/ai_act.go
@@ -1,0 +1,16 @@
+package preset
+
+import "github.com/taoq-ai/wuming/domain/model"
+
+func init() {
+	register(Preset{
+		Name:        "ai-act",
+		Description: "EU AI Act — scrub training/validation data for high-risk AI systems (Articles 10, 15)",
+		Locales: []string{
+			"au", "br", "ca", "cn", "common", "de", "eu",
+			"fr", "gb", "in", "jp", "kr", "nl", "us",
+		},
+		PIITypes:    allPIITypes(),
+		MinSeverity: model.Low,
+	})
+}

--- a/adapter/preset/preset_test.go
+++ b/adapter/preset/preset_test.go
@@ -9,7 +9,7 @@ import (
 func TestListReturnsAllPresets(t *testing.T) {
 	names := List()
 	want := []string{
-		"appi", "dpdp", "gdpr", "hipaa", "lgpd",
+		"ai-act", "appi", "dpdp", "gdpr", "hipaa", "lgpd",
 		"pci-dss", "pipa", "pipeda", "pipl", "privacy-act",
 	}
 	if len(names) != len(want) {
@@ -48,6 +48,19 @@ func TestGetUnknownPresetReturnsError(t *testing.T) {
 	_, err := Get("nonexistent")
 	if err == nil {
 		t.Error("Get(\"nonexistent\") should return an error")
+	}
+}
+
+func TestAIActPreset(t *testing.T) {
+	p, _ := Get("ai-act")
+	assertLocales(t, p, []string{
+		"au", "br", "ca", "cn", "common", "de", "eu",
+		"fr", "gb", "in", "jp", "kr", "nl", "us",
+	})
+	assertSeverity(t, p, model.Low)
+	// AI Act covers all PII types across all locales.
+	if len(p.PIITypes) != len(allPIITypes()) {
+		t.Errorf("ai-act: got %d PII types, want %d", len(p.PIITypes), len(allPIITypes()))
 	}
 }
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -15,7 +15,7 @@ You can list all available presets programmatically:
 import "github.com/taoq-ai/wuming/adapter/preset"
 
 names := preset.List()
-// ["appi", "dpdp", "gdpr", "hipaa", "lgpd", "pci-dss", "pipa", "pipeda", "pipl", "privacy-act"]
+// ["ai-act", "appi", "dpdp", "gdpr", "hipaa", "lgpd", "pci-dss", "pipa", "pipeda", "pipl", "privacy-act"]
 ```
 
 ## Available Presets
@@ -27,6 +27,19 @@ names := preset.List()
 - **Locales**: common, eu, nl, de, fr, gb
 - **PII types**: all
 - **Min severity**: Low
+
+### AI Act
+
+**EU AI Act** -- scrub training and validation data for high-risk AI systems (Articles 10, 15).
+
+- **Locales**: all 14 (au, br, ca, cn, common, de, eu, fr, gb, in, jp, kr, nl, us)
+- **PII types**: all
+- **Min severity**: Low
+
+```go
+w := wuming.New(wuming.WithPreset("ai-act"))
+result, err := w.Process(ctx, text)
+```
 
 ### HIPAA
 


### PR DESCRIPTION
## Summary
- Adds `ai-act` compliance preset covering all 14 locales and all PII types at Low severity, targeting Articles 10 and 15 of the EU AI Act for training/validation data governance
- Adds test case verifying the preset includes all locales and PII types
- Updates README and docs/presets.md with AI Act documentation

Closes #80

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Review preset definition matches EU AI Act requirements